### PR TITLE
Implement timestamps and fix issues

### DIFF
--- a/XDMA/linux-kernel/xdma/alinx_ptp.c
+++ b/XDMA/linux-kernel/xdma/alinx_ptp.c
@@ -117,6 +117,7 @@ static int alinx_ptp_settime(struct ptp_clock_info *ptp, const struct timespec64
 
         ptp_data->offset = host_timestamp - hw_timestamp;
 
+        set_cycle_1s(ptp_data, RESERVED_CYCLE);
         set_pulse_at(ptp_data, sys_clock);
 
         spin_unlock_irqrestore(&ptp_data->lock, flags);

--- a/XDMA/linux-kernel/xdma/alinx_ptp.c
+++ b/XDMA/linux-kernel/xdma/alinx_ptp.c
@@ -60,8 +60,9 @@ timestamp_t alinx_get_rx_timestamp(struct pci_dev* pdev, sysclock_t sysclock) {
 
 timestamp_t alinx_get_tx_timestamp(struct pci_dev* pdev, int tx_id) {
         int64_t adjustment = 0; // TODO: Use exact value
+        sysclock_t tmp = alinx_read_tx_timestamp(pdev, tx_id);
 
-        return alinx_read_tx_timestamp(pdev, tx_id) + adjustment;
+        return alinx_sysclock_to_timestamp(pdev, tmp) + adjustment;
 }
 
 static int alinx_ptp_gettimex(struct ptp_clock_info *ptp, struct timespec64 *ts,

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1363,6 +1363,9 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 	struct xdma_engine *engine;
 	struct xdma_private *priv;
 	struct xdma_result *result;
+#ifdef __LIBXDMA_DEBUG__
+	struct rx_buffer * rx_buffer;
+#endif
 
 	dbg_irq("(irq=%d, dev 0x%p) <<<< ISR.\n", irq, dev_id);
 	if (!dev_id) {
@@ -1406,6 +1409,7 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 		result = priv->res;
 
 #ifdef __LIBXDMA_DEBUG__
+		rx_buffer = (struct rx_buffer*)&priv->rx_buffer;
 		assert_eq(rx_buffer->metadata.frame_length, result->length - RX_METADATA_SIZE);
 #endif
 		spin_lock_irqsave(&priv->rx_lock, flag);

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1435,7 +1435,7 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 			skb_len);
 		skb->dev = ndev;
 		skb->protocol = eth_type_trans(skb, ndev);
-		// TODO: skb->tstamp = alinx_get_timestamp(rx_buffer->metadata.timestamp); // TODO: change to get_rx_timestamp
+		skb->tstamp = alinx_get_rx_timestamp(xdev->pdev, alinx_get_sys_clock(xdev->pdev));
 
 		/* Transfer the skb to the Linux network stack */
 		netif_rx(skb);

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1398,11 +1398,11 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 		return IRQ_NONE;
 	}
 
+	priv = netdev_priv(ndev);
 	mask = ch_irq & xdev->mask_irq_c2h;
 	if (mask) {
 		dbg_info("xdma_isr c2h");
 		engine = &xdev->engine_c2h[0];
-		priv = netdev_priv(ndev);
 		result = priv->res;
 
 #ifdef __LIBXDMA_DEBUG__

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -173,17 +173,25 @@ void tsn_init_configs(struct pci_dev* pdev) {
 
 static void bake_qos_config(struct tsn_config* config) {
 	int slot_id, vlan_prio; // Iterators
+	bool qav_disabled = true;
 	struct qbv_baked_config* baked;
 	if (config->qbv.enabled == false) {
 		// TODO: remove this when throughput issue without QoS gets resolved
-		config->qbv.enabled = true;
-		config->qbv.start = 0;
-		config->qbv.slot_count = 2;
-		config->qbv.slots[0].duration_ns = 500000000; // 500ms
-		config->qbv.slots[1].duration_ns = 500000000; // 500ms
 		for (vlan_prio = 0; vlan_prio < VLAN_PRIO_COUNT; vlan_prio++) {
-			config->qbv.slots[0].opened_prios[vlan_prio] = true;
-			config->qbv.slots[1].opened_prios[vlan_prio] = true;
+			if (config->qav[vlan_prio].enabled) {
+				qav_disabled = false;
+				break;
+			}
+		}
+
+		if (qav_disabled) {
+			config->qbv.enabled = true;
+			config->qbv.start = 0;
+			config->qbv.slot_count = 1;
+			config->qbv.slots[0].duration_ns = 1000000000; // 1s
+			for (vlan_prio = 0; vlan_prio < VLAN_PRIO_COUNT; vlan_prio++) {
+				config->qbv.slots[0].opened_prios[vlan_prio] = true;
+			}
 		}
 	}
 

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -140,14 +140,14 @@ void tsn_init_configs(struct pci_dev* pdev) {
 	memset(config, 0, sizeof(struct tsn_config));
 
 	// Example Qbv configuration
-	if (false) {
+	if (true) {
 		config->qbv.enabled = true;
 		config->qbv.start = 0;
 		config->qbv.slot_count = 2;
 		config->qbv.slots[0].duration_ns = 500000000; // 500ms
 		config->qbv.slots[0].opened_prios[0] = true;
 		config->qbv.slots[1].duration_ns = 500000000; // 500ms
-		config->qbv.slots[1].opened_prios[0] = false;
+		config->qbv.slots[1].opened_prios[0] = true;
 	}
 
 	// Example Qav configuration
@@ -413,6 +413,19 @@ int tsn_set_qbv(struct pci_dev* pdev, struct tc_taprio_qopt_offload* qopt) {
 
 	if (qopt->num_entries > MAX_QBV_SLOTS) {
 		return -EINVAL;
+	}
+
+	if (!qopt->enable) {
+		// TODO: remove this when throughput issue without QoS gets resolved
+		config->qbv.enabled = true;
+		config->qbv.start = 0;
+		config->qbv.slot_count = 2;
+		config->qbv.slots[0].duration_ns = 500000000;
+		config->qbv.slots[0].opened_prios[0] = true;
+		config->qbv.slots[1].duration_ns = 500000000;
+		config->qbv.slots[1].opened_prios[0] = true;
+		bake_qbv_config(config);
+		return 0;
 	}
 
 	config->qbv.enabled = qopt->enable;

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -124,11 +124,11 @@ bool tsn_fill_metadata(struct pci_dev* pdev, timestamp_t now, struct sk_buff* sk
 	metadata->delay_to.priority = queue_prio;
 
 	if (priv->tstamp_config.tx_type != HWTSTAMP_TX_ON) {
-		metadata->timestamp_id = 0;
+		metadata->timestamp_id = TSN_TIMESTAMP_ID_NONE;
 	} else if (is_gptp) {
-		metadata->timestamp_id = 2;
+		metadata->timestamp_id = TSN_TIMESTAMP_ID_GPTP;
 	} else {
-		metadata->timestamp_id = 1;
+		metadata->timestamp_id = TSN_TIMESTAMP_ID_NORMAL;
 	}
 
 	// Update available_ats

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -143,6 +143,7 @@ bool tsn_fill_metadata(struct pci_dev* pdev, timestamp_t now, struct sk_buff* sk
 }
 
 void tsn_init_configs(struct pci_dev* pdev) {
+	uint8_t i;
 	struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
 	struct tsn_config* config = &xdev->tsn_config;
 	memset(config, 0, sizeof(struct tsn_config));
@@ -153,9 +154,11 @@ void tsn_init_configs(struct pci_dev* pdev) {
 		config->qbv.start = 0;
 		config->qbv.slot_count = 2;
 		config->qbv.slots[0].duration_ns = 500000000; // 500ms
-		config->qbv.slots[0].opened_prios[0] = true;
 		config->qbv.slots[1].duration_ns = 500000000; // 500ms
-		config->qbv.slots[1].opened_prios[0] = true;
+		for (i = 0; i < VLAN_PRIO_COUNT; i++) {
+			config->qbv.slots[0].opened_prios[i] = true;
+			config->qbv.slots[1].opened_prios[i] = true;
+		}
 	}
 
 	// Example Qav configuration
@@ -428,10 +431,12 @@ int tsn_set_qbv(struct pci_dev* pdev, struct tc_taprio_qopt_offload* qopt) {
 		config->qbv.enabled = true;
 		config->qbv.start = 0;
 		config->qbv.slot_count = 2;
-		config->qbv.slots[0].duration_ns = 500000000;
-		config->qbv.slots[0].opened_prios[0] = true;
-		config->qbv.slots[1].duration_ns = 500000000;
-		config->qbv.slots[1].opened_prios[0] = true;
+		config->qbv.slots[0].duration_ns = 500000000; // 500ms
+		config->qbv.slots[1].duration_ns = 500000000; // 500ms
+		for (i = 0; i < VLAN_PRIO_COUNT; i++) {
+			config->qbv.slots[0].opened_prios[i] = true;
+			config->qbv.slots[1].opened_prios[i] = true;
+		}
 		bake_qbv_config(config);
 		return 0;
 	}

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -113,7 +113,6 @@ bool tsn_fill_metadata(struct pci_dev* pdev, timestamp_t now, struct sk_buff* sk
 		metadata->fail_policy = consider_delay ? TSN_FAIL_POLICY_RETRY : TSN_FAIL_POLICY_DROP;
 	}
 
-	// TODO: Convert ns to sysclock
 	metadata->from.tick = alinx_timestamp_to_sysclock(pdev, timestamps.from);
 	metadata->from.priority = queue_prio;
 	metadata->to.tick = alinx_timestamp_to_sysclock(pdev, timestamps.to);
@@ -122,6 +121,7 @@ bool tsn_fill_metadata(struct pci_dev* pdev, timestamp_t now, struct sk_buff* sk
 	metadata->delay_from.priority = queue_prio;
 	metadata->delay_to.tick = alinx_timestamp_to_sysclock(pdev, timestamps.delay_to);
 	metadata->delay_to.priority = queue_prio;
+	metadata->timestamp_id = 1;  // TODO: Set correct timestamp_id according to packet type
 
 	// Update available_ats
 	spend_qav_credit(tsn_config, from, vlan_prio, metadata->frame_length);

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -349,6 +349,9 @@ static bool get_timestamps(struct timestamps* timestamps, const struct tsn_confi
 
 	// 2. "to"
 	timestamps->to = timestamps->from + baked_prio->slots[slot_id].duration_ns;
+	if (baked_prio->slot_count == 2 && baked_prio->slots[1].opened == false) {
+		timestamps->to += _DEFAULT_TO_MARGIN_;
+	}
 
 	if (consider_delay) {
 		// 3. "delay_from"

--- a/XDMA/linux-kernel/xdma/tsn.h
+++ b/XDMA/linux-kernel/xdma/tsn.h
@@ -8,6 +8,12 @@
 typedef uint64_t timestamp_t;
 typedef uint64_t sysclock_t;
 
+enum tsn_timestamp_id {
+	TSN_TIMESTAMP_ID_NONE = 0,
+	TSN_TIMESTAMP_ID_GPTP = 1,
+	TSN_TIMESTAMP_ID_NORMAL = 2,
+};
+
 enum tsn_prio {
 	TSN_PRIO_GPTP = 3,
 	TSN_PRIO_VLAN = 5,

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -156,6 +156,7 @@ static const struct net_device_ops xdma_netdev_ops = {
 	.ndo_stop = xdma_netdev_close,
 	.ndo_start_xmit = xdma_netdev_start_xmit,
 	.ndo_setup_tc = xdma_netdev_setup_tc,
+	.ndo_eth_ioctl = xdma_netdev_ioctl,
 };
 
 static int xdma_ethtool_get_ts_info(struct net_device * ndev, struct ethtool_ts_info * info) {

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -353,6 +353,8 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 		goto err_out;
 	}
 
+	INIT_WORK(&priv->tx_work, xdma_tx_work);
+
 	ptp_data = ptp_device_init(&pdev->dev, xdev);
 	if (!ptp_data) {
 		pr_err("ptp_device_init failed\n");

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -165,7 +165,6 @@ static int xdma_ethtool_get_ts_info(struct net_device * ndev, struct ethtool_ts_
 
 	info->phc_index = ptp_clock_index(xpdev->ptp->ptp_clock);
 
-	// TODO: put correct values
 	info->so_timestamping = SOF_TIMESTAMPING_TX_SOFTWARE |
 							SOF_TIMESTAMPING_RX_SOFTWARE |
 							SOF_TIMESTAMPING_SOFTWARE |

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -203,6 +203,38 @@ int xdma_netdev_setup_tc(struct net_device *ndev, enum tc_setup_type type, void 
         return 0;
 }
 
+static int xdma_get_ts_config(struct net_device *ndev, struct ifreq *ifr) {
+        struct xdma_private *priv = netdev_priv(ndev);
+        struct hwtstamp_config *config = &priv->tstamp_config;
+
+        return copy_to_user(ifr->ifr_data, config, sizeof(*config)) ? -EFAULT : 0;
+}
+
+static int xdma_set_ts_config(struct net_device *ndev, struct ifreq *ifr) {
+        struct xdma_private *priv = netdev_priv(ndev);
+        struct hwtstamp_config config;
+        int err;
+
+        if (copy_from_user(&config, ifr->ifr_data, sizeof(config))) {
+                return -EFAULT;
+        }
+
+        // TODO: Handle unsupported options
+
+        return 0;
+}
+
+int xdma_netdev_ioctl(struct net_device *ndev, struct ifreq *ifr, int cmd) {
+        switch (cmd) {
+        case SIOCGHWTSTAMP:
+                return xdma_get_ts_config(ndev, ifr);
+        case SIOCSHWTSTAMP:
+                return xdma_set_ts_config(ndev, ifr);
+        default:
+                return -EOPNOTSUPP;
+        }
+}
+
 void xdma_tx_work(struct work_struct *work) {
         struct skb_shared_hwtstamps shhwtstamps;
         struct xdma_private *priv = container_of(work, struct xdma_private, tx_work);

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -138,7 +138,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
                         priv->tx_work_skb = skb_get(skb);
                         schedule_work(&priv->tx_work);
                 }
-                // TODO: track the number of skipped packets
+                // TODO: track the number of skipped packets for ethtool stats
         }
 
         xdma_debug("skb->len : %d\n", skb->len);
@@ -215,13 +215,7 @@ static int xdma_set_ts_config(struct net_device *ndev, struct ifreq *ifr) {
         struct xdma_private *priv = netdev_priv(ndev);
         struct hwtstamp_config *config = &priv->tstamp_config;
 
-        if (copy_from_user(config, ifr->ifr_data, sizeof(*config))) {
-                return -EFAULT;
-        }
-
-        // TODO: Handle unsupported options
-
-        return 0;
+        return copy_from_user(config, ifr->ifr_data, sizeof(*config)) ? -EFAULT : 0;
 }
 
 int xdma_netdev_ioctl(struct net_device *ndev, struct ifreq *ifr, int cmd) {

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -107,7 +107,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
         /* Check desc count */
         netif_stop_queue(ndev);
         xdma_debug("xdma_netdev_start_xmit(skb->len : %d)\n", skb->len);
-        skb->len = max(ETH_ZLEN, skb->len);
+        skb->len = max((unsigned int)ETH_ZLEN, skb->len);
         if (skb_padto(skb, skb->len)) {
                 pr_err("skb_padto failed\n");
                 dev_kfree_skb(skb);

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -83,6 +83,8 @@ int xdma_netdev_open(struct net_device *ndev)
 
 int xdma_netdev_close(struct net_device *ndev)
 {
+        struct xdma_private *priv = netdev_priv(ndev);
+        iowrite32(DMA_ENGINE_STOP, &priv->rx_engine->regs->control);
         netif_stop_queue(ndev);
         pr_info("xdma_netdev_close\n");
         netif_carrier_off(ndev);

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -104,7 +104,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
         /* Check desc count */
         netif_stop_queue(ndev);
         xdma_debug("xdma_netdev_start_xmit(skb->len : %d)\n", skb->len);
-        skb->len = (skb->len < ETH_ZLEN) ? (ETH_ZLEN - skb->len) : 0;
+        skb->len += (skb->len < ETH_ZLEN) ? (ETH_ZLEN - skb->len) : 0;
         if (skb_padto(skb, skb->len)) {
                 pr_err("skb_padto failed\n");
                 dev_kfree_skb(skb);

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -105,7 +105,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
         /* Check desc count */
         netif_stop_queue(ndev);
         xdma_debug("xdma_netdev_start_xmit(skb->len : %d)\n", skb->len);
-        skb->len += (skb->len < ETH_ZLEN) ? (ETH_ZLEN - skb->len) : 0;
+        skb->len = max(ETH_ZLEN, skb->len);
         if (skb_padto(skb, skb->len)) {
                 pr_err("skb_padto failed\n");
                 dev_kfree_skb(skb);

--- a/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -145,6 +145,8 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
  */
 int xdma_netdev_setup_tc(struct net_device *ndev, enum tc_setup_type type, void *type_data);
 
+int xdma_netdev_ioctl(struct net_device *ndev, struct ifreq *ifr, int cmd);
+
 void xdma_tx_work(struct work_struct *work);
 
 #endif

--- a/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -7,6 +7,7 @@
 #include <linux/workqueue.h>
 #include <linux/mutex.h>
 #include <linux/spinlock.h>
+#include <linux/net_tstamp.h>
 
 #include "xdma_mod.h"
 
@@ -24,6 +25,10 @@
 #define DESC_BUSY 2
 
 #define CRC_LEN 4
+
+enum xdma_state_t {
+        XDMA_TX_IN_PROGRESS,
+};
 
 struct xdma_private {
         struct pci_dev *pdev;
@@ -51,6 +56,12 @@ struct xdma_private {
         spinlock_t rx_lock;
         int irq;
         int rx_count;
+
+        struct work_struct tx_work;
+        struct sk_buff *tx_work_skb;
+        struct hwtstamp_config tstamp_config;
+
+        unsigned long state;
 };
 
 #define _DEFAULT_FROM_MARGIN_ (500)
@@ -133,5 +144,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
  * @type_data: parameters passed to the tc command
  */
 int xdma_netdev_setup_tc(struct net_device *ndev, enum tc_setup_type type, void *type_data);
+
+void xdma_tx_work(struct work_struct *work);
 
 #endif

--- a/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -65,7 +65,7 @@ struct xdma_private {
 };
 
 #define _DEFAULT_FROM_MARGIN_ (500)
-#define _DEFAULT_TO_MARGIN_ (19100)
+#define _DEFAULT_TO_MARGIN_ (50000)
 struct tick_count {
         uint32_t tick:29;
         uint32_t priority:3;


### PR DESCRIPTION
TX, RX 타임스탬프를 구현하고 ioctl과 연동하였으며, 그 과정에서 발견한 몇 가지 문제를 수정하였습니다. 수정사항 및 기타 언급해야 할 사항은 다음과 같습니다.

1. ptp_settime() 함수에서 cycle_1s를 설정하는 부분을 삭제했었는데, ([link](https://github.com/tsnlab/2023-krri-tci-xdma/commit/52e873b1751ccb9deff91d5f97ac01e0415746d6#diff-eba6393f171ec864b0c95ec2ef2f57fd8e114aaa9b21284d6f5116bdcce13386L110)) 그것을 복구했습니다. settime() 함수는 싱크를 조절할 때가 아니라 초기화할 때 호출되는 것으로 보이며, 이 부분이 없으면 master에서는 cycle_1s가 한 번도 설정되지 않아 싱크에 문제가 발생합니다. (특히 한 번 slave로 phc2sys를 실행하여 cycle_1s 값이 바뀌었을 경우)

2. QoS의 기본값을 Qbv를 모두 open한 상태로 설정했습니다. 현재 발생하고 있는 QoS가 없을 때 throughput이 감소하는 문제를 우회하기 위한 것이며, 그대로 놔두면 테스트에 불편함이 있어 임시로 이렇게 해 두었습니다. 이 문제가 해결되면 다시 되돌릴 예정입니다.

3. PTP 패킷의 타입에 따라 RX Timestamp 적용 여부를 결정하도록 구현은 했지만 ([link](https://github.com/tsnlab/2023-krri-tci-xdma/commit/4910a0f6c289bb51214775bdcd1197ba2a1aacf7#diff-09384e6aa73a33b0ee86c6c5efe15d401a5e0c87596de0b68a05d86efdc40506R1349-R1375)) 지금은 테스트를 할 수 없어 (latency 측정 중) 검증은 되지 않았습니다. 추후에 PTP로 timestamp 테스트한 후에 수정이 필요하면 반영하도록 하겠습니다.
