### PR TITLE
Fix throughput issue

### DIFF
--- a/XDMA/linux-kernel/xdma/alinx_arch.c
+++ b/XDMA/linux-kernel/xdma/alinx_arch.c
@@ -1,5 +1,6 @@
 #include "alinx_arch.h"
 #include "libxdma.h"
+#include "xdma_netdev.h"
 
 #ifdef __linux__
 
@@ -76,12 +77,20 @@ timestamp_t alinx_read_tx_timestamp(struct pci_dev* pdev, int tx_id) {
 
 u32 alinx_get_tx_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
-        return read32(xdev->bar[0] + REG_TX_PACKETS);
+        struct xdma_private* priv = netdev_priv(xdev->ndev);
+        u32 regval = read32(xdev->bar[0] + REG_TX_PACKETS);
+        priv->tx_count += regval;
+
+        return priv->tx_count;
 }
 
 u32 alinx_get_tx_drop_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
-        return read32(xdev->bar[0] + REG_TX_DROP_PACKETS);
+        struct xdma_private* priv = netdev_priv(xdev->ndev);
+        u32 regval = read32(xdev->bar[0] + REG_TX_DROP_PACKETS);
+        priv->tx_drop_count += regval;
+
+        return priv->tx_drop_count;
 }
 
 #ifdef __LIBXDMA_DEBUG__

--- a/XDMA/linux-kernel/xdma/alinx_arch.c
+++ b/XDMA/linux-kernel/xdma/alinx_arch.c
@@ -79,18 +79,18 @@ u32 alinx_get_tx_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
         struct xdma_private* priv = netdev_priv(xdev->ndev);
         u32 regval = read32(xdev->bar[0] + REG_TX_PACKETS);
-        priv->tx_count += regval;
+        priv->total_tx_count += regval;
 
-        return priv->tx_count;
+        return priv->total_tx_count;
 }
 
 u32 alinx_get_tx_drop_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
         struct xdma_private* priv = netdev_priv(xdev->ndev);
         u32 regval = read32(xdev->bar[0] + REG_TX_DROP_PACKETS);
-        priv->tx_drop_count += regval;
+        priv->total_tx_drop_count += regval;
 
-        return priv->tx_drop_count;
+        return priv->total_tx_drop_count;
 }
 
 #ifdef __LIBXDMA_DEBUG__

--- a/XDMA/linux-kernel/xdma/alinx_arch.c
+++ b/XDMA/linux-kernel/xdma/alinx_arch.c
@@ -74,6 +74,16 @@ timestamp_t alinx_read_tx_timestamp(struct pci_dev* pdev, int tx_id) {
         }
 }
 
+u32 alinx_get_tx_packets(struct pci_dev *pdev) {
+        struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
+        return read32(xdev->bar[0] + REG_TX_PACKETS);
+}
+
+u32 alinx_get_tx_drop_packets(struct pci_dev *pdev) {
+        struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
+        return read32(xdev->bar[0] + REG_TX_DROP_PACKETS);
+}
+
 #ifdef __LIBXDMA_DEBUG__
 void dump_buffer(unsigned char* buffer, int len)
 {

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -115,7 +115,7 @@ struct qav_state {
 };
 
 struct buffer_tracker {
-	uint64_t entry_count;
+	uint64_t pending_packets;
 	uint64_t last_tx_count;
 };
 

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -115,8 +115,8 @@ struct qav_state {
 };
 
 struct buffer_tracker {
-	uint32_t entry_count;
-	uint32_t last_tx_count;
+	uint64_t entry_count;
+	uint64_t last_tx_count;
 };
 
 struct tsn_config {

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -114,19 +114,12 @@ struct qav_state {
 	timestamp_t available_at;
 };
 
-struct buffer_tracker {
-	sysclock_t free_at[HW_QUEUE_SIZE];
-	int head; // Insert
-	int tail; // Remove
-	int count;
-};
-
 struct tsn_config {
 	struct qbv_config qbv;
 	struct qbv_baked_config qbv_baked;
 	struct qav_state qav[VLAN_PRIO_COUNT];
 	struct mqprio_config mqprio;
-	struct buffer_tracker buffer_tracker;
+	uint32_t buffer_count;
 	timestamp_t queue_available_at[TSN_PRIO_COUNT];
 	timestamp_t total_available_at;
 };

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -29,6 +29,9 @@ typedef uint32_t u32
 #define REG_TX_TIMESTAMP4_HIGH 0x0340
 #define REG_TX_TIMESTAMP4_LOW 0x0344
 
+#define REG_TX_PACKETS 0x0200
+#define REG_TX_DROP_PACKETS 0x0220
+
 #define TX_QUEUE_COUNT 3
 
 /* 125 MHz */
@@ -38,6 +41,7 @@ typedef uint32_t u32
 #define HW_QUEUE_SIZE (128)
 #define BE_QUEUE_SIZE (HW_QUEUE_SIZE - 20)
 #define TSN_QUEUE_SIZE (HW_QUEUE_SIZE - 2)
+#define HW_QUEUE_SIZE_PAD 20
 
 #define VLAN_PRIO_COUNT 8
 #define TSN_PRIO_COUNT 8
@@ -135,6 +139,8 @@ sysclock_t alinx_get_sys_clock(struct pci_dev *pdev);
 void alinx_set_cycle_1s(struct pci_dev *pdev, u32 cycle_1s);
 u32 alinx_get_cycle_1s(struct pci_dev *pdev);
 timestamp_t alinx_read_tx_timestamp(struct pci_dev *pdev, int tx_id);
+u32 alinx_get_tx_packets(struct pci_dev *pdev);
+u32 alinx_get_tx_drop_packets(struct pci_dev *pdev);
 
 void dump_buffer(unsigned char* buffer, int len);
 

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -114,12 +114,17 @@ struct qav_state {
 	timestamp_t available_at;
 };
 
+struct buffer_tracker {
+	uint32_t entry_count;
+	uint32_t last_tx_count;
+};
+
 struct tsn_config {
 	struct qbv_config qbv;
 	struct qbv_baked_config qbv_baked;
 	struct qav_state qav[VLAN_PRIO_COUNT];
 	struct mqprio_config mqprio;
-	uint32_t buffer_count;
+	struct buffer_tracker buffer_tracker;
 	timestamp_t queue_available_at[TSN_PRIO_COUNT];
 	timestamp_t total_available_at;
 };

--- a/XDMA/linux-kernel/xdma/alinx_ptp.c
+++ b/XDMA/linux-kernel/xdma/alinx_ptp.c
@@ -46,10 +46,9 @@ timestamp_t alinx_sysclock_to_timestamp(struct pci_dev* pdev, sysclock_t syscloc
         struct xdma_pci_dev *xpdev = dev_get_drvdata(&pdev->dev);
         struct ptp_device_data* ptp_data = xpdev->ptp;
 
-        double ticks_scale = (double)NS_IN_1S / alinx_get_cycle_1s(pdev);
         u64 offset = ptp_data->offset;
 
-        return alinx_get_timestamp(sysclock, ticks_scale, offset);
+        return alinx_get_timestamp(sysclock, ptp_data->ticks_scale, offset);
 }
 
 timestamp_t alinx_get_rx_timestamp(struct pci_dev* pdev, sysclock_t sysclock) {

--- a/XDMA/linux-kernel/xdma/alinx_ptp.h
+++ b/XDMA/linux-kernel/xdma/alinx_ptp.h
@@ -18,4 +18,7 @@ timestamp_t alinx_sysclock_to_timestamp(struct pci_dev* pdev, sysclock_t syscloc
 timestamp_t alinx_get_rx_timestamp(struct pci_dev* pdev, sysclock_t sysclock);
 timestamp_t alinx_get_tx_timestamp(struct pci_dev* pdev, int tx_id);
 
+double alinx_get_ticks_scale(struct pci_dev* pdev);
+void alinx_set_ticks_scale(struct pci_dev* pdev, double ticks_scale);
+
 #endif /* ALINX_PTP_H */

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -33,6 +33,7 @@
 #include "cdev_sgdma.h"
 #include "xdma_thread.h"
 #include "xdma_netdev.h"
+#include "tsn.h"
 
 
 #ifdef __LIBXDMA_DEBUG__
@@ -1510,6 +1511,7 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 		dma_unmap_single(&xdev->pdev->dev, priv->tx_dma_addr, priv->tx_skb->len, DMA_TO_DEVICE);
 		dev_kfree_skb_any(priv->tx_skb);
 		priv->tx_skb = NULL;
+		tsn_pop_buffer_track(xdev->pdev);
 
 		iowrite32(DMA_ENGINE_STOP, &engine->regs->control);
 		netif_wake_queue(ndev);

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1511,7 +1511,6 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 		dma_unmap_single(&xdev->pdev->dev, priv->tx_dma_addr, priv->tx_skb->len, DMA_TO_DEVICE);
 		dev_kfree_skb_any(priv->tx_skb);
 		priv->tx_skb = NULL;
-		tsn_update_buffer_track(xdev->pdev);
 
 		iowrite32(DMA_ENGINE_STOP, &engine->regs->control);
 		netif_wake_queue(ndev);

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1511,7 +1511,7 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 		dma_unmap_single(&xdev->pdev->dev, priv->tx_dma_addr, priv->tx_skb->len, DMA_TO_DEVICE);
 		dev_kfree_skb_any(priv->tx_skb);
 		priv->tx_skb = NULL;
-		tsn_pop_buffer_track(xdev->pdev);
+		tsn_update_buffer_track(xdev->pdev);
 
 		iowrite32(DMA_ENGINE_STOP, &engine->regs->control);
 		netif_wake_queue(ndev);

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -24,6 +24,7 @@ static bool get_timestamps(struct timestamps* timestamps, const struct tsn_confi
 
 // HW Buffer tracker
 static bool append_buffer_track(struct buffer_tracker* buffer_tracker);
+static void update_buffer_track(struct pci_dev* pdev);
 
 static uint8_t tsn_get_vlan_prio(struct tsn_config* tsn_config, struct sk_buff* skb) {
 	struct tx_buffer* tx_buf = (struct tx_buffer*)skb->data;
@@ -70,6 +71,8 @@ bool tsn_fill_metadata(struct pci_dev* pdev, timestamp_t now, struct sk_buff* sk
 	struct tsn_config* tsn_config = &xdev->tsn_config;
 	struct buffer_tracker* buffer_tracker = &tsn_config->buffer_tracker;
 	struct xdma_private* priv = netdev_priv(xdev->ndev);
+
+	update_buffer_track(pdev);
 
 	vlan_prio = tsn_get_vlan_prio(tsn_config, skb);
 	is_gptp = is_gptp_packet(tx_buf->data);
@@ -385,7 +388,7 @@ static bool append_buffer_track(struct buffer_tracker* buffer_tracker) {
 	return true;
 }
 
-void tsn_update_buffer_track(struct pci_dev* pdev) {
+static void update_buffer_track(struct pci_dev* pdev) {
 	struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
 	struct buffer_tracker* buffer_tracker = &xdev->tsn_config.buffer_tracker;
 	u64 tx_count, pop_count;

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -388,7 +388,7 @@ static bool append_buffer_track(struct buffer_tracker* buffer_tracker) {
 void tsn_pop_buffer_track(struct pci_dev* pdev) {
 	struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
 	struct buffer_tracker* buffer_tracker = &xdev->tsn_config.buffer_tracker;
-	u32 tx_count, pop_count;
+	u64 tx_count, pop_count;
 
 	if (buffer_tracker->entry_count >= HW_QUEUE_SIZE - HW_QUEUE_SIZE_PAD) {
 		tx_count = alinx_get_tx_packets(pdev) + alinx_get_tx_drop_packets(pdev);

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -397,6 +397,17 @@ static bool cleanup_buffer_track(struct buffer_tracker* tracker, sysclock_t now)
 	return true;
 }
 
+void tsn_pop_buffer_track(struct pci_dev* pdev) {
+	struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
+	struct tsn_config* tsn_config = &xdev->tsn_config;
+	struct buffer_tracker* tracker = &tsn_config->buffer_tracker;
+
+	if (tracker->count > 0) {
+		tracker->tail = (tracker->tail + 1) % HW_QUEUE_SIZE;
+		tracker->count -= 1;
+	}
+}
+
 int tsn_set_mqprio(struct pci_dev* pdev, struct tc_mqprio_qopt_offload* qopt) {
 	u8 i;
 

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -401,10 +401,12 @@ void tsn_pop_buffer_track(struct pci_dev* pdev) {
 	struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
 	struct tsn_config* tsn_config = &xdev->tsn_config;
 	struct buffer_tracker* tracker = &tsn_config->buffer_tracker;
+	u32 pop_cnt;
 
-	if (tracker->count > 0) {
-		tracker->tail = (tracker->tail + 1) % HW_QUEUE_SIZE;
-		tracker->count -= 1;
+	if (tracker->count >= HW_QUEUE_SIZE - HW_QUEUE_SIZE_PAD) {
+		pop_cnt = min((u32)tracker->count, alinx_get_tx_packets(pdev) + alinx_get_tx_drop_packets(pdev));
+		tracker->tail = (tracker->tail + pop_cnt) % HW_QUEUE_SIZE;
+		tracker->count -= pop_cnt;
 	}
 }
 

--- a/XDMA/linux-kernel/xdma/tsn.h
+++ b/XDMA/linux-kernel/xdma/tsn.h
@@ -43,4 +43,4 @@ int tsn_set_mqprio(struct pci_dev* pdev, struct tc_mqprio_qopt_offload* qopt);
 int tsn_set_qav(struct pci_dev* pdev, struct tc_cbs_qopt_offload* qopt);
 int tsn_set_qbv(struct pci_dev* pdev, struct tc_taprio_qopt_offload* qopt);
 
-void tsn_pop_buffer_track(struct pci_dev* pdev);
+void tsn_update_buffer_track(struct pci_dev* pdev);

--- a/XDMA/linux-kernel/xdma/tsn.h
+++ b/XDMA/linux-kernel/xdma/tsn.h
@@ -42,5 +42,3 @@ void tsn_init_configs(struct pci_dev* config);
 int tsn_set_mqprio(struct pci_dev* pdev, struct tc_mqprio_qopt_offload* qopt);
 int tsn_set_qav(struct pci_dev* pdev, struct tc_cbs_qopt_offload* qopt);
 int tsn_set_qbv(struct pci_dev* pdev, struct tc_taprio_qopt_offload* qopt);
-
-void tsn_update_buffer_track(struct pci_dev* pdev);

--- a/XDMA/linux-kernel/xdma/tsn.h
+++ b/XDMA/linux-kernel/xdma/tsn.h
@@ -42,3 +42,5 @@ void tsn_init_configs(struct pci_dev* config);
 int tsn_set_mqprio(struct pci_dev* pdev, struct tc_mqprio_qopt_offload* qopt);
 int tsn_set_qav(struct pci_dev* pdev, struct tc_cbs_qopt_offload* qopt);
 int tsn_set_qbv(struct pci_dev* pdev, struct tc_taprio_qopt_offload* qopt);
+
+void tsn_pop_buffer_track(struct pci_dev* pdev);

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -276,7 +276,7 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 	iowrite32(0x10, xdev->bar[0] + 0x620);
 
 	/* Allocate the network device */
-	ndev = alloc_etherdev_mq(sizeof(struct xdma_private), TX_QUEUE_COUNT);
+	ndev = alloc_etherdev(sizeof(struct xdma_private));
 	if (!ndev) {
 		pr_err("alloc_etherdev failed\n");
 		rv = -ENOMEM;

--- a/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -65,8 +65,8 @@ struct xdma_private {
         sysclock_t last_tx_tstamp[TSN_TIMESTAMP_ID_MAX];
         int tstamp_retry[TSN_TIMESTAMP_ID_MAX];
 
-        uint32_t tx_count;
-        uint32_t tx_drop_count;
+        uint64_t total_tx_count;
+        uint64_t total_tx_drop_count;
 
         unsigned long state;
 };

--- a/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -65,6 +65,9 @@ struct xdma_private {
         sysclock_t last_tx_tstamp[TSN_TIMESTAMP_ID_MAX];
         int tstamp_retry[TSN_TIMESTAMP_ID_MAX];
 
+        uint32_t tx_count;
+        uint32_t tx_drop_count;
+
         unsigned long state;
 };
 


### PR DESCRIPTION
Throughput이 현저히 떨어지던 문제를 수정했습니다.

수정 사항은 다음과 같습니다.

1. OS에 등록하는 queue의 수를 4개에서 1개로 줄였습니다. 이로 인해 tc로 QoS 설정은 할 수 없게 되었지만 당장 throughput 문제를 해결하기 위해 이렇게 두었습니다. 추가적인 조사가 필요합니다.

2. Tx 인터럽트가 발생할 때 레지스터에서 전송되거나 드랍된 패킷의 수를 읽어와서 버퍼 트래커에서 빼주도록 했습니다. 이로 인해 트래커에서 빼줄 시기를 정해줄 필요가 없어져서 buffer_tracker 구조체를 삭제하고 count 정수 하나만 남겼습니다.

3. Timestamp를 계산할 때 `ticks <-> nanosec` 변환 과정에서 ticks_scale 값을 매번 레지스터의 CYCLE_1S 값을 읽어와서 계산하지 않고 미리 ptp에 저장된 값을 사용하도록 했습니다.

4. 사소한 변경 사항으로 alinx_ptp.c에서 1초를 nanosec 단위로 계산할 때 숫자(1000000000)를 사용하던 것을 매크로(NS_IN_1S)를 사용하도록 했습니다.