### PR TITLE
Fix issues

### DIFF
--- a/XDMA/linux-kernel/xdma/alinx_arch.c
+++ b/XDMA/linux-kernel/xdma/alinx_arch.c
@@ -76,6 +76,7 @@ timestamp_t alinx_read_tx_timestamp(struct pci_dev* pdev, int tx_id) {
 }
 
 static void add_u32_counter(u64* sum, u32 value) {
+        /* Handle overflows of 32-bit counters */
         u32 diff = value - (u32)*sum;
         *sum += (u64)diff;
 }

--- a/XDMA/linux-kernel/xdma/alinx_arch.c
+++ b/XDMA/linux-kernel/xdma/alinx_arch.c
@@ -120,6 +120,13 @@ u32 alinx_get_to_overflow_timeout_packets(struct pci_dev *pdev) {
         return regval;
 }
 
+u32 alinx_get_total_tx_drop_packets(struct pci_dev *pdev) {
+        return alinx_get_tx_drop_packets(pdev)
+                + alinx_get_normal_timeout_packets(pdev)
+                + alinx_get_to_overflow_popped_packets(pdev)
+                + alinx_get_to_overflow_timeout_packets(pdev);
+}
+
 #ifdef __LIBXDMA_DEBUG__
 void dump_buffer(unsigned char* buffer, int len)
 {

--- a/XDMA/linux-kernel/xdma/alinx_arch.c
+++ b/XDMA/linux-kernel/xdma/alinx_arch.c
@@ -93,6 +93,33 @@ u32 alinx_get_tx_drop_packets(struct pci_dev *pdev) {
         return priv->total_tx_drop_count;
 }
 
+u32 alinx_get_normal_timeout_packets(struct pci_dev *pdev) {
+        struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
+        u32 regval = read32(xdev->bar[0] + REG_NORMAL_TIMEOUT_COUNT);
+        // This register does not get cleared when read
+        // TODO: Handle overflow?
+
+        return regval;
+}
+
+u32 alinx_get_to_overflow_popped_packets(struct pci_dev *pdev) {
+        struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
+        u32 regval = read32(xdev->bar[0] + REG_TO_OVERFLOW_POPPED_COUNT);
+        // This register does not get cleared when read
+        // TODO: Handle overflow?
+
+        return regval;
+}
+
+u32 alinx_get_to_overflow_timeout_packets(struct pci_dev *pdev) {
+        struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
+        u32 regval = read32(xdev->bar[0] + REG_TO_OVERFLOW_TIMEOUT_COUNT);
+        // This register does not get cleared when read
+        // TODO: Handle overflow?
+
+        return regval;
+}
+
 #ifdef __LIBXDMA_DEBUG__
 void dump_buffer(unsigned char* buffer, int len)
 {

--- a/XDMA/linux-kernel/xdma/alinx_arch.c
+++ b/XDMA/linux-kernel/xdma/alinx_arch.c
@@ -75,6 +75,11 @@ timestamp_t alinx_read_tx_timestamp(struct pci_dev* pdev, int tx_id) {
         }
 }
 
+static void add_u32_counter(u64* sum, u32 value) {
+        u32 diff = value - (u32)*sum;
+        *sum += (u64)diff;
+}
+
 u64 alinx_get_tx_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
         struct xdma_private* priv = netdev_priv(xdev->ndev);
@@ -97,13 +102,7 @@ u64 alinx_get_normal_timeout_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
         struct xdma_private* priv = netdev_priv(xdev->ndev);
         u32 regval = read32(xdev->bar[0] + REG_NORMAL_TIMEOUT_COUNT);
-
-        if (regval < (u32)(priv->last_normal_timeout & 0xFFFFFFFF)) {
-                // Overflow
-                priv->last_normal_timeout += 0x100000000;
-        }
-        priv->last_normal_timeout &= 0xFFFFFFFF00000000;
-        priv->last_normal_timeout |= (u64)regval;
+        add_u32_counter(&priv->last_normal_timeout, regval);
 
         return priv->last_normal_timeout;
 }
@@ -112,13 +111,7 @@ u64 alinx_get_to_overflow_popped_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
         struct xdma_private* priv = netdev_priv(xdev->ndev);
         u32 regval = read32(xdev->bar[0] + REG_TO_OVERFLOW_POPPED_COUNT);
-
-        if (regval < (u32)(priv->last_to_overflow_popped & 0xFFFFFFFF)) {
-                // Overflow
-                priv->last_to_overflow_popped += 0x100000000;
-        }
-        priv->last_to_overflow_popped &= 0xFFFFFFFF00000000;
-        priv->last_to_overflow_popped |= (u64)regval;
+        add_u32_counter(&priv->last_to_overflow_popped, regval);
 
         return priv->last_to_overflow_popped;
 }
@@ -127,13 +120,7 @@ u64 alinx_get_to_overflow_timeout_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
         struct xdma_private* priv = netdev_priv(xdev->ndev);
         u32 regval = read32(xdev->bar[0] + REG_TO_OVERFLOW_TIMEOUT_COUNT);
-
-        if (regval < (u32)(priv->last_to_overflow_timeout & 0xFFFFFFFF)) {
-                // Overflow
-                priv->last_to_overflow_timeout += 0x100000000;
-        }
-        priv->last_to_overflow_timeout &= 0xFFFFFFFF00000000;
-        priv->last_to_overflow_timeout |= (u64)regval;
+        add_u32_counter(&priv->last_to_overflow_timeout, regval);
 
         return priv->last_to_overflow_timeout;
 }

--- a/XDMA/linux-kernel/xdma/alinx_arch.c
+++ b/XDMA/linux-kernel/xdma/alinx_arch.c
@@ -83,6 +83,8 @@ static void add_u32_counter(u64* sum, u32 value) {
 u64 alinx_get_tx_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
         struct xdma_private* priv = netdev_priv(xdev->ndev);
+
+        /* This register gets cleared after read */
         u32 regval = read32(xdev->bar[0] + REG_TX_PACKETS);
         priv->total_tx_count += regval;
 
@@ -92,6 +94,8 @@ u64 alinx_get_tx_packets(struct pci_dev *pdev) {
 u64 alinx_get_tx_drop_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
         struct xdma_private* priv = netdev_priv(xdev->ndev);
+
+        /* This register gets cleared after read */
         u32 regval = read32(xdev->bar[0] + REG_TX_DROP_PACKETS);
         priv->total_tx_drop_count += regval;
 
@@ -101,6 +105,8 @@ u64 alinx_get_tx_drop_packets(struct pci_dev *pdev) {
 u64 alinx_get_normal_timeout_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
         struct xdma_private* priv = netdev_priv(xdev->ndev);
+
+        /* This register does not get cleared after read */
         u32 regval = read32(xdev->bar[0] + REG_NORMAL_TIMEOUT_COUNT);
         add_u32_counter(&priv->last_normal_timeout, regval);
 
@@ -110,6 +116,8 @@ u64 alinx_get_normal_timeout_packets(struct pci_dev *pdev) {
 u64 alinx_get_to_overflow_popped_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
         struct xdma_private* priv = netdev_priv(xdev->ndev);
+
+        /* This register does not get cleared after read */
         u32 regval = read32(xdev->bar[0] + REG_TO_OVERFLOW_POPPED_COUNT);
         add_u32_counter(&priv->last_to_overflow_popped, regval);
 
@@ -119,6 +127,8 @@ u64 alinx_get_to_overflow_popped_packets(struct pci_dev *pdev) {
 u64 alinx_get_to_overflow_timeout_packets(struct pci_dev *pdev) {
         struct xdma_dev* xdev = xdev_find_by_pdev(pdev);
         struct xdma_private* priv = netdev_priv(xdev->ndev);
+
+        /* This register does not get cleared after read */
         u32 regval = read32(xdev->bar[0] + REG_TO_OVERFLOW_TIMEOUT_COUNT);
         add_u32_counter(&priv->last_to_overflow_timeout, regval);
 

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -145,6 +145,7 @@ u32 alinx_get_tx_drop_packets(struct pci_dev *pdev);
 u32 alinx_get_normal_timeout_packets(struct pci_dev *pdev);
 u32 alinx_get_to_overflow_popped_packets(struct pci_dev *pdev);
 u32 alinx_get_to_overflow_timeout_packets(struct pci_dev *pdev);
+u32 alinx_get_total_tx_drop_packets(struct pci_dev *pdev);
 
 void dump_buffer(unsigned char* buffer, int len);
 

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -140,12 +140,12 @@ sysclock_t alinx_get_sys_clock(struct pci_dev *pdev);
 void alinx_set_cycle_1s(struct pci_dev *pdev, u32 cycle_1s);
 u32 alinx_get_cycle_1s(struct pci_dev *pdev);
 timestamp_t alinx_read_tx_timestamp(struct pci_dev *pdev, int tx_id);
-u32 alinx_get_tx_packets(struct pci_dev *pdev);
-u32 alinx_get_tx_drop_packets(struct pci_dev *pdev);
-u32 alinx_get_normal_timeout_packets(struct pci_dev *pdev);
-u32 alinx_get_to_overflow_popped_packets(struct pci_dev *pdev);
-u32 alinx_get_to_overflow_timeout_packets(struct pci_dev *pdev);
-u32 alinx_get_total_tx_drop_packets(struct pci_dev *pdev);
+u64 alinx_get_tx_packets(struct pci_dev *pdev);
+u64 alinx_get_tx_drop_packets(struct pci_dev *pdev);
+u64 alinx_get_normal_timeout_packets(struct pci_dev *pdev);
+u64 alinx_get_to_overflow_popped_packets(struct pci_dev *pdev);
+u64 alinx_get_to_overflow_timeout_packets(struct pci_dev *pdev);
+u64 alinx_get_total_tx_drop_packets(struct pci_dev *pdev);
 
 void dump_buffer(unsigned char* buffer, int len);
 

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -31,6 +31,9 @@ typedef uint32_t u32
 
 #define REG_TX_PACKETS 0x0200
 #define REG_TX_DROP_PACKETS 0x0220
+#define REG_NORMAL_TIMEOUT_COUNT 0x041c
+#define REG_TO_OVERFLOW_POPPED_COUNT 0x0420
+#define REG_TO_OVERFLOW_TIMEOUT_COUNT 0x0424
 
 #define TX_QUEUE_COUNT 3
 
@@ -139,6 +142,9 @@ u32 alinx_get_cycle_1s(struct pci_dev *pdev);
 timestamp_t alinx_read_tx_timestamp(struct pci_dev *pdev, int tx_id);
 u32 alinx_get_tx_packets(struct pci_dev *pdev);
 u32 alinx_get_tx_drop_packets(struct pci_dev *pdev);
+u32 alinx_get_normal_timeout_packets(struct pci_dev *pdev);
+u32 alinx_get_to_overflow_popped_packets(struct pci_dev *pdev);
+u32 alinx_get_to_overflow_timeout_packets(struct pci_dev *pdev);
 
 void dump_buffer(unsigned char* buffer, int len);
 

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1483,7 +1483,7 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 			priv->rx_buffer + RX_METADATA_SIZE,
 			skb_len);
 		if (filter_rx_timestamp(priv, skb)) {
-			skb_hwtstamps(skb)->hwtstamp = alinx_get_rx_timestamp(xdev->pdev, alinx_get_sys_clock(xdev->pdev));
+			skb_hwtstamps(skb)->hwtstamp = alinx_get_rx_timestamp(xdev->pdev, rx_buffer->metadata.timestamp);
 		}
 		skb->dev = ndev;
 		skb->protocol = eth_type_trans(skb, ndev);

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -398,7 +398,7 @@ static void update_buffer_track(struct pci_dev* pdev) {
 		return;
 	}
 
-	tx_count = alinx_get_tx_packets(pdev) + alinx_get_tx_drop_packets(pdev);
+	tx_count = alinx_get_tx_packets(pdev) + alinx_get_tx_drop_packets(pdev) + alinx_get_normal_timeout_packets(pdev) + alinx_get_to_overflow_popped_packets(pdev) + alinx_get_to_overflow_timeout_packets(pdev);
 	pop_count = tx_count - buffer_tracker->last_tx_count;
 	buffer_tracker->last_tx_count = tx_count;
 	pop_count = min(pop_count, buffer_tracker->pending_packets);

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -398,7 +398,7 @@ static void update_buffer_track(struct pci_dev* pdev) {
 		return;
 	}
 
-	tx_count = alinx_get_tx_packets(pdev) + alinx_get_tx_drop_packets(pdev) + alinx_get_normal_timeout_packets(pdev) + alinx_get_to_overflow_popped_packets(pdev) + alinx_get_to_overflow_timeout_packets(pdev);
+	tx_count = alinx_get_tx_packets(pdev) + alinx_get_total_tx_drop_packets(pdev);
 	pop_count = tx_count - buffer_tracker->last_tx_count;
 	buffer_tracker->last_tx_count = tx_count;
 	pop_count = min(pop_count, buffer_tracker->pending_packets);

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -175,6 +175,8 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
                 netif_wake_queue(ndev);
                 return NETDEV_TX_BUSY;
         }
+
+        /* netif_wake_queue() will be called in xdma_isr() */
         priv->tx_dma_addr = dma_addr;
         priv->tx_skb = skb;
         tx_desc_set(priv->tx_desc, dma_addr, skb->len);

--- a/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -67,6 +67,9 @@ struct xdma_private {
 
         uint64_t total_tx_count;
         uint64_t total_tx_drop_count;
+        uint64_t last_normal_timeout;
+        uint64_t last_to_overflow_popped;
+        uint64_t last_to_overflow_timeout;
 
         unsigned long state;
 };


### PR DESCRIPTION
여러 가지 작은 오류를 수정했습니다.

1. Rx timestamp를 메타데이터가 아닌 당시의 sys_clock 값을 사용하던 것을 수정했습니다.

2. Tx 중 오류가 발생했을 때 (버퍼가 가득 찼을 때 등) queue를 깨우도록 수정했습니다.
  - 현재 xdma_netdev_start_xmit() 함수에서는 시작할 때 queue를 멈춰놓습니다. (netif_stop_queue())
  - 정상적으로 Tx가 이루어질 때에는 xdma_isr() 함수에서 netif_wake_queue()가 호출되지만, 오류가 발생하면 호출되지 않아 Tx가 멈추는 문제가 있습니다.
  - 오류로 인해 xdma_netdev_start_xmit() 함수에서 리턴할 때 netif_wake_queue()를 호출하도록 했습니다.

3. 버퍼 트래커에서 드랍된 패킷을 추적할 때 읽어야 하는 레지스터들을 추가했습니다.