### PR TITLE
Use randomised MAC address from host ID

### DIFF
--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -49,17 +49,20 @@ static int xpdev_cnt;
 
 static bool get_host_id(uint64_t* hostid) {
 	void* buf = NULL;
-	loff_t offsize;
+	size_t size;
 	int ret;
-	ret = kernel_read_file_from_path("/etc/machine-id", &buf, &offsize, INT_MAX, READING_UNKNOWN);
+	bool result;
+	ret = kernel_read_file_from_path("/etc/machine-id", 0, &buf, INT_MAX, NULL, READING_UNKNOWN);
 	if (ret < 0) {
 		pr_err("Failed to read machine-id\n");
 		return false;
 	}
 
-	if (offsize != 33) {
+	size = ret;
+
+	if (size != 33) {
 		pr_err("Invalid machine-id\n");
-		ret = false;
+		result = false;
 		goto end;
 	}
 
@@ -68,10 +71,10 @@ static bool get_host_id(uint64_t* hostid) {
 
 	if (ret = kstrtoull(buf, 16, hostid)) {
 		pr_err("Failed to convert machine-id to uint64_t: %d\n", ret);
-		ret = false;
+		result = false;
 		goto end;
 	}
-	ret = true;
+	result = true;
 
 end:
 	vfree(buf);

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -96,13 +96,13 @@ static void get_mac_address(char* mac_addr, struct pci_dev *pdev) {
 	uint64_t hash = hash(machine_id, pcie_num);
 
 	// Convert to MAC address
-	// Note that x2:xx:xx:xx:xx:xx is Locally Administered MAC Address
 	for (i = 0; i < ETH_ALEN; i++) {
 		mac_addr[i] = (hash >> (i * 8)) & 0xFF;
 	}
 
-	// Make addr = x2:xx:xx:xx:xx:xx
-	mac_addr[0] = mac_addr[0] & 0xf0 | 0x02;
+	// Adjust U/L, I/G bits
+	mac_addr[0] &= ~0x1; // Unicast
+	mac_addr[0] &= ~0x2; // Global
 }
 
 static const struct pci_device_id pci_ids[] = {

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -89,11 +89,11 @@ static uint64_t hash(unsigned long hostid, unsigned long num) {
 	return hash;
 }
 
-static void get_mac_address(char* mac_addr, struct pci_dev *pdev) {
+static void get_mac_address(char* mac_addr, struct xdma_dev *xdev) {
 	int i;
 	void* data = NULL;
 	unsigned long long machine_id;
-	unsigned char pcie_num = 0; // FIXME
+	unsigned char pcie_num = xdev->idx; // FIXME: Use proper PCIe number
 
 	if (get_host_id(&machine_id) == false) {
 		machine_id = 0; // Fallback value
@@ -401,7 +401,7 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 
 	/* Set the MAC address */
 	unsigned char mac_addr[ETH_ALEN];
-	get_mac_address(mac_addr, pdev);
+	get_mac_address(mac_addr, xdev);
 	memcpy(ndev->dev_addr, mac_addr, ETH_ALEN);
 
 	priv->rx_buffer = kmalloc(XDMA_BUFFER_SIZE, GFP_KERNEL);

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -93,7 +93,7 @@ static void get_mac_address(char* mac_addr, struct pci_dev *pdev) {
 	int i;
 	void* data = NULL;
 	unsigned long long machine_id;
-	unsigned char pcie_num = pdev->slot->number;
+	unsigned char pcie_num = 0; // FIXME
 
 	if (get_host_id(&machine_id) == false) {
 		machine_id = 0; // Fallback value

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -63,7 +63,14 @@ static bool get_host_id(uint64_t* hostid) {
 		goto end;
 	}
 
-	kstrtoull(buf, 16, hostid);
+	// Cut it to 64-bit
+	((char*)buf)[16] = '\0';
+
+	if (ret = kstrtoull(buf, 16, hostid)) {
+		pr_err("Failed to convert machine-id to uint64_t: %d\n", ret);
+		ret = false;
+		goto end;
+	}
 	ret = true;
 
 end:

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -78,7 +78,7 @@ static bool get_host_id(uint64_t* hostid) {
 
 end:
 	vfree(buf);
-	return ret;
+	return result;
 }
 
 static uint64_t hash(unsigned long hostid, unsigned long num) {


### PR DESCRIPTION
아직 롬에 MAC 주소가 저장되지 않아 호스트마다 고유한 아이디를 이용해 생성된 랜덤 MAC 주소를 사용하도록 합니다.
한 호스트에 NIC이 여러 대 장착되는 경우 PCIe 슬롯 번호를 가져오면 좋지만 아직 그 부분은 구현을 못 해 `xdev->idx` 값을 사용합니다.