### PR TITLE
Fix various bugs in calculations

### DIFF
--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -50,8 +50,8 @@ typedef uint32_t u32
 #define TSN_PRIO_COUNT 8
 #define MAX_QBV_SLOTS 20
 
-#define ETHERNET_GAP_SIZE = (8 + 4 + 12) // 8 bytes preamble, 4 bytes FCS, 12 bytes interpacket gap
-#define PHY_DELAY_CLOCKS = 14 // 14 clocks from MAC to PHY
+#define ETHERNET_GAP_SIZE (8 + 4 + 12) // 8 bytes preamble, 4 bytes FCS, 12 bytes interpacket gap
+#define PHY_DELAY_CLOCKS 14 // 14 clocks from MAC to PHY
 
 typedef u64 sysclock_t;
 typedef u64 timestamp_t;

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -51,6 +51,7 @@ typedef uint32_t u32
 #define MAX_QBV_SLOTS 20
 
 #define ETHERNET_GAP_SIZE = (8 + 4 + 12) // 8 bytes preamble, 4 bytes FCS, 12 bytes interpacket gap
+#define PHY_DELAY_CLOCKS = 14 // 14 clocks from MAC to PHY
 
 typedef u64 sysclock_t;
 typedef u64 timestamp_t;

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -50,7 +50,7 @@ typedef uint32_t u32
 #define TSN_PRIO_COUNT 8
 #define MAX_QBV_SLOTS 20
 
-#define MIN_FRAME_SIZE (8 + ETH_ZLEN + 4 + 12) // 8 bytes preamble, 60 bytes payload, 4 bytes FCS, 12 bytes interpacket gap
+#define ETHERNET_GAP_SIZE = (8 + 4 + 12) // 8 bytes preamble, 4 bytes FCS, 12 bytes interpacket gap
 
 typedef u64 sysclock_t;
 typedef u64 timestamp_t;

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -116,13 +116,13 @@ bool tsn_fill_metadata(struct pci_dev* pdev, timestamp_t now, struct sk_buff* sk
 		metadata->fail_policy = consider_delay ? TSN_FAIL_POLICY_RETRY : TSN_FAIL_POLICY_DROP;
 	}
 
-	metadata->from.tick = alinx_timestamp_to_sysclock(pdev, timestamps.from);
+	metadata->from.tick = alinx_timestamp_to_sysclock(pdev, timestamps.from) - PHY_DELAY_CLOCKS;
 	metadata->from.priority = queue_prio;
-	metadata->to.tick = alinx_timestamp_to_sysclock(pdev, timestamps.to);
+	metadata->to.tick = alinx_timestamp_to_sysclock(pdev, timestamps.to) - PHY_DELAY_CLOCKS;
 	metadata->to.priority = queue_prio;
-	metadata->delay_from.tick = alinx_timestamp_to_sysclock(pdev, timestamps.delay_from);
+	metadata->delay_from.tick = alinx_timestamp_to_sysclock(pdev, timestamps.delay_from) - PHY_DELAY_CLOCKS;
 	metadata->delay_from.priority = queue_prio;
-	metadata->delay_to.tick = alinx_timestamp_to_sysclock(pdev, timestamps.delay_to);
+	metadata->delay_to.tick = alinx_timestamp_to_sysclock(pdev, timestamps.delay_to) - PHY_DELAY_CLOCKS;
 	metadata->delay_to.priority = queue_prio;
 
 	if (priv->tstamp_config.tx_type != HWTSTAMP_TX_ON) {

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -243,7 +243,7 @@ static void bake_qos_config(struct tsn_config* config) {
 static uint64_t bytes_to_ns(uint64_t bytes) {
 	// TODO: Get link speed
 	uint64_t link_speed = 1000000000; // Assume 1Gbps
-	return max(bytes, (uint64_t)MIN_FRAME_SIZE) * 8 * NS_IN_1S / link_speed;
+	return max(bytes, (uint64_t)ETH_ZLEN) * 8 * NS_IN_1S / link_speed;
 }
 
 static void spend_qav_credit(struct tsn_config* tsn_config, timestamp_t at, uint8_t vlan_prio, uint64_t bytes) {


### PR DESCRIPTION
- [x] If current slot is about to end that cannot fit the packet, skip that slot
- [x] Sanity check if `__LIBXDMA_DEBUG__` flag is on
- [x] Correctly calculate frame size (interframe gap was ignored when the packet is bigger than ZLEN)
- [x] Correct MAC2PHY delay (Actual TX time is exactly 14 clocks later from sending)