### PR TITLE
Fix timestamp issues

### DIFF
--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -355,9 +355,6 @@ static bool get_timestamps(struct timestamps* timestamps, const struct tsn_confi
 
 	// 2. "to"
 	timestamps->to = timestamps->from + baked_prio->slots[slot_id].duration_ns;
-	if (baked_prio->slot_count == 2 && baked_prio->slots[1].opened == false) {
-		timestamps->to += _DEFAULT_TO_MARGIN_;
-	}
 
 	if (consider_delay) {
 		// 3. "delay_from"

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -424,7 +424,11 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 		goto err_out;
 	}
 
-	INIT_WORK(&priv->tx_work, xdma_tx_work);
+	/* Tx works for each timestamp id */
+	INIT_WORK(&priv->tx_work[1], xdma_tx_work1);
+	INIT_WORK(&priv->tx_work[2], xdma_tx_work2);
+	INIT_WORK(&priv->tx_work[3], xdma_tx_work3);
+	INIT_WORK(&priv->tx_work[4], xdma_tx_work4);
 
 	ptp_data = ptp_device_init(&pdev->dev, xdev);
 	if (!ptp_data) {

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -188,7 +188,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
                                 // Overflow
                                 priv->tx_work_start_after[tx_metadata->timestamp_id] += 0x20000000;
                         }
-                        priv->tx_work_wait_until[tx_metadata->timestamp_id] = sys_count_lower | tx_metadata->to.tick;
+                        priv->tx_work_wait_until[tx_metadata->timestamp_id] = sys_count_upper | tx_metadata->to.tick;
                         if (sys_count_lower > tx_metadata->to.tick) {
                                 // Overflow
                                 priv->tx_work_wait_until[tx_metadata->timestamp_id] += 0x20000000;

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -172,7 +172,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
                         skb_shinfo(skb)->tx_flags |= SKBTX_IN_PROGRESS;
                         priv->tx_work_skb[tx_metadata->timestamp_id] = skb_get(skb);
                         priv->tx_work_wait_until[tx_metadata->timestamp_id] = (sys_count & ~0x1FFFFFFF) | tx_metadata->to.tick;
-                        if (sys_count & 0x1FFFFFFF > tx_metadata->to.tick) {
+                        if ((sys_count & 0x1FFFFFFF) > tx_metadata->to.tick) {
                                 // Overflow
                                 priv->tx_work_wait_until[tx_metadata->timestamp_id] += 0x20000000;
                         }
@@ -254,7 +254,6 @@ void xdma_tx_work##tstamp_id(struct work_struct *work) { \
         struct skb_shared_hwtstamps shhwtstamps; \
         struct xdma_private* priv = container_of(work - tstamp_id, struct xdma_private, tx_work[0]); \
         struct sk_buff* skb = priv->tx_work_skb[tstamp_id]; \
-        struct tx_buffer* tx_buf = (struct tx_buffer*)skb->data; \
  \
         if (!priv->tx_work_skb[tstamp_id]) { \
                 clear_bit_unlock(XDMA_TX##tstamp_id##_IN_PROGRESS, &priv->state); \

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -10,7 +10,7 @@
 #include "tsn.h"
 #include "alinx_arch.h"
 
-#define LOWER_29_BITS 0x1FFFFFFFULL
+#define LOWER_29_BITS ((1ULL << 29) - 1)
 #define TX_WORK_OVERFLOW_MARGIN 100
 
 static void tx_desc_set(struct xdma_desc *desc, dma_addr_t addr, u32 len)
@@ -188,13 +188,13 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
                         priv->tx_work_start_after[tx_metadata->timestamp_id] = sys_count_upper | tx_metadata->from.tick;
                         if (sys_count_lower > tx_metadata->from.tick && sys_count_lower - tx_metadata->from.tick > TX_WORK_OVERFLOW_MARGIN) {
                                 // Overflow
-                                priv->tx_work_start_after[tx_metadata->timestamp_id] += 0x20000000;
+                                priv->tx_work_start_after[tx_metadata->timestamp_id] += (1 << 29);
                         }
                         to_value = (tx_metadata->fail_policy == TSN_FAIL_POLICY_RETRY ? tx_metadata->delay_to.tick : tx_metadata->to.tick);
                         priv->tx_work_wait_until[tx_metadata->timestamp_id] = sys_count_upper | to_value;
                         if (sys_count_lower > to_value && sys_count_lower - to_value > TX_WORK_OVERFLOW_MARGIN) {
                                 // Overflow
-                                priv->tx_work_wait_until[tx_metadata->timestamp_id] += 0x20000000;
+                                priv->tx_work_wait_until[tx_metadata->timestamp_id] += (1 << 29);
                         }
                         schedule_work(&priv->tx_work[tx_metadata->timestamp_id]);
                 }

--- a/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -64,6 +64,7 @@ struct xdma_private {
 
         struct work_struct tx_work[TSN_TIMESTAMP_ID_MAX];
         struct sk_buff *tx_work_skb[TSN_TIMESTAMP_ID_MAX];
+        sysclock_t tx_work_start_after[TSN_TIMESTAMP_ID_MAX];
         sysclock_t tx_work_wait_until[TSN_TIMESTAMP_ID_MAX];
         struct hwtstamp_config tstamp_config;
         sysclock_t last_tx_tstamp[TSN_TIMESTAMP_ID_MAX];

--- a/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -29,7 +29,10 @@
 #define TX_TSTAMP_MAX_RETRY 5
 
 enum xdma_state_t {
-        XDMA_TX_IN_PROGRESS,
+        XDMA_TX1_IN_PROGRESS = 1,
+        XDMA_TX2_IN_PROGRESS = 2,
+        XDMA_TX3_IN_PROGRESS = 3,
+        XDMA_TX4_IN_PROGRESS = 4,
 };
 
 struct xdma_private {
@@ -59,8 +62,9 @@ struct xdma_private {
         int irq;
         int rx_count;
 
-        struct work_struct tx_work;
-        struct sk_buff *tx_work_skb;
+        struct work_struct tx_work[TSN_TIMESTAMP_ID_MAX];
+        struct sk_buff *tx_work_skb[TSN_TIMESTAMP_ID_MAX];
+        sysclock_t tx_work_wait_until[TSN_TIMESTAMP_ID_MAX];
         struct hwtstamp_config tstamp_config;
         sysclock_t last_tx_tstamp[TSN_TIMESTAMP_ID_MAX];
         int tstamp_retry[TSN_TIMESTAMP_ID_MAX];
@@ -157,6 +161,9 @@ int xdma_netdev_setup_tc(struct net_device *ndev, enum tc_setup_type type, void 
 
 int xdma_netdev_ioctl(struct net_device *ndev, struct ifreq *ifr, int cmd);
 
-void xdma_tx_work(struct work_struct *work);
+void xdma_tx_work1(struct work_struct *work);
+void xdma_tx_work2(struct work_struct *work);
+void xdma_tx_work3(struct work_struct *work);
+void xdma_tx_work4(struct work_struct *work);
 
 #endif


### PR DESCRIPTION
타임스탬프 및 Qbv와 관련된 이슈를 수정했습니다.

1. Tx timestamp id 별로 work를 하나씩 할당했습니다.
  - ptp4l과 성능 측정 도구를 동시에 실행하면 Tx timestamp를 가져올 때 서로에게 방해를 받아 필요한 때에 timestamp를 가져오지 못하는 경우가 생겨 이렇게 수정했습니다.

2. Tx timestamp를 from이 지난 이후에 읽도록 했습니다.
  - 가끔씩 ptp4l의 싱크가 튀는 현상을 발견했는데, 이전에 보내진 패킷의 timestamp를 현재 패킷의 timestamp로 인식해 발생하는 문제로 추정되기도 했고, 아직 보내질 수 없는 패킷에 대해 timestamp를 읽는 것이 의미가 없다고 판단하여 이렇게 했습니다.

3. Tx timestamp를 읽을 때의 재시도 횟수를 to가 지났을 때에만 제한하도록 했습니다.
  - 아직 패킷이 보내지지 않았는데 읽기 재시도 횟수를 초과하여 timestamp가 찍히지 않는 문제를 수정했습니다.
  - 패킷이 보내진 뒤에도 timestamp 업데이트가 늦어지는 경우를 고려하여 to가 지나도 일정 횟수 재시도하는 부분은 남겨두었습니다.
  - 'to' 값은 fail policy가 retry인 경우 delay_to를 사용합니다.

4. Qbv가 적용되어 from, to 값을 계산할 때 to 값에 더해지던 margin 값을 제거했습니다.