### PR TITLE
Adjust timestamps and fix Qbv issue

### DIFF
--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -53,6 +53,9 @@ typedef uint32_t u32
 #define ETHERNET_GAP_SIZE (8 + 4 + 12) // 8 bytes preamble, 4 bytes FCS, 12 bytes interpacket gap
 #define PHY_DELAY_CLOCKS 14 // 14 clocks from MAC to PHY
 
+#define TX_ADJUST_NS 100/* MAC */ + 262/* PHY */
+#define RX_ADJUST_NS 188/* MAC */ + 262/* PHY */
+
 typedef u64 sysclock_t;
 typedef u64 timestamp_t;
 

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -56,6 +56,8 @@ typedef uint32_t u32
 #define TX_ADJUST_NS 100/* MAC */ + 262/* PHY */
 #define RX_ADJUST_NS 188/* MAC */ + 262/* PHY */
 
+#define H2C_LATENCY 30000 // TODO: Adjust this value dynamically
+
 typedef u64 sysclock_t;
 typedef u64 timestamp_t;
 

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -53,8 +53,8 @@ typedef uint32_t u32
 #define ETHERNET_GAP_SIZE (8 + 4 + 12) // 8 bytes preamble, 4 bytes FCS, 12 bytes interpacket gap
 #define PHY_DELAY_CLOCKS 14 // 14 clocks from MAC to PHY
 
-#define TX_ADJUST_NS 100/* MAC */ + 262/* PHY */
-#define RX_ADJUST_NS 188/* MAC */ + 262/* PHY */
+#define TX_ADJUST_NS 100/* MAC */ + 200/* PHY */
+#define RX_ADJUST_NS 188/* MAC */ + 324/* PHY */
 
 #define H2C_LATENCY 30000 // TODO: Adjust this value dynamically
 

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -53,10 +53,10 @@ typedef uint32_t u32
 #define ETHERNET_GAP_SIZE (8 + 4 + 12) // 8 bytes preamble, 4 bytes FCS, 12 bytes interpacket gap
 #define PHY_DELAY_CLOCKS 14 // 14 clocks from MAC to PHY
 
-#define TX_ADJUST_NS 100/* MAC */ + 200/* PHY */
-#define RX_ADJUST_NS 188/* MAC */ + 324/* PHY */
+#define TX_ADJUST_NS (100 + 200)  // MAC + PHY
+#define RX_ADJUST_NS (188 + 324)  // MAC + PHY
 
-#define H2C_LATENCY 30000 // TODO: Adjust this value dynamically
+#define H2C_LATENCY_NS 30000 // TODO: Adjust this value dynamically
 
 typedef u64 sysclock_t;
 typedef u64 timestamp_t;

--- a/XDMA/linux-kernel/xdma/alinx_ptp.c
+++ b/XDMA/linux-kernel/xdma/alinx_ptp.c
@@ -62,7 +62,7 @@ timestamp_t alinx_get_tx_timestamp(struct pci_dev* pdev, int tx_id) {
         return alinx_sysclock_to_timestamp(pdev, sysclock) + TX_ADJUST_NS;
 }
 
-timestamp_t alinx_get_tx_timestamp2(struct pci_dev* pdev, sysclock_t sysclock) {
+timestamp_t alinx_sysclock_to_txtstamp(struct pci_dev* pdev, sysclock_t sysclock) {
         return alinx_sysclock_to_timestamp(pdev, sysclock) + TX_ADJUST_NS;
 }
 

--- a/XDMA/linux-kernel/xdma/alinx_ptp.c
+++ b/XDMA/linux-kernel/xdma/alinx_ptp.c
@@ -53,16 +53,17 @@ timestamp_t alinx_sysclock_to_timestamp(struct pci_dev* pdev, sysclock_t syscloc
 }
 
 timestamp_t alinx_get_rx_timestamp(struct pci_dev* pdev, sysclock_t sysclock) {
-        int64_t adjustment = 0; // TODO: Use exact value
-
-        return alinx_sysclock_to_timestamp(pdev, sysclock) + adjustment;
+        return alinx_sysclock_to_timestamp(pdev, sysclock) - RX_ADJUST_NS;
 }
 
 timestamp_t alinx_get_tx_timestamp(struct pci_dev* pdev, int tx_id) {
-        int64_t adjustment = 0; // TODO: Use exact value
-        sysclock_t tmp = alinx_read_tx_timestamp(pdev, tx_id);
+        sysclock_t sysclock = alinx_read_tx_timestamp(pdev, tx_id);
 
-        return alinx_sysclock_to_timestamp(pdev, tmp) + adjustment;
+        return alinx_sysclock_to_timestamp(pdev, sysclock) + TX_ADJUST_NS;
+}
+
+timestamp_t alinx_get_tx_timestamp2(struct pci_dev* pdev, sysclock_t sysclock) {
+        return alinx_sysclock_to_timestamp(pdev, sysclock) + TX_ADJUST_NS;
 }
 
 double alinx_get_ticks_scale(struct pci_dev* pdev) {

--- a/XDMA/linux-kernel/xdma/alinx_ptp.h
+++ b/XDMA/linux-kernel/xdma/alinx_ptp.h
@@ -17,7 +17,7 @@ sysclock_t alinx_timestamp_to_sysclock(struct pci_dev* pdev, timestamp_t timesta
 timestamp_t alinx_sysclock_to_timestamp(struct pci_dev* pdev, sysclock_t sysclock);
 timestamp_t alinx_get_rx_timestamp(struct pci_dev* pdev, sysclock_t sysclock);
 timestamp_t alinx_get_tx_timestamp(struct pci_dev* pdev, int tx_id);
-timestamp_t alinx_get_tx_timestamp2(struct pci_dev* pdev, sysclock_t sysclock);
+timestamp_t alinx_sysclock_to_txtstamp(struct pci_dev* pdev, sysclock_t sysclock);
 
 double alinx_get_ticks_scale(struct pci_dev* pdev);
 void alinx_set_ticks_scale(struct pci_dev* pdev, double ticks_scale);

--- a/XDMA/linux-kernel/xdma/alinx_ptp.h
+++ b/XDMA/linux-kernel/xdma/alinx_ptp.h
@@ -17,6 +17,7 @@ sysclock_t alinx_timestamp_to_sysclock(struct pci_dev* pdev, timestamp_t timesta
 timestamp_t alinx_sysclock_to_timestamp(struct pci_dev* pdev, sysclock_t sysclock);
 timestamp_t alinx_get_rx_timestamp(struct pci_dev* pdev, sysclock_t sysclock);
 timestamp_t alinx_get_tx_timestamp(struct pci_dev* pdev, int tx_id);
+timestamp_t alinx_get_tx_timestamp2(struct pci_dev* pdev, sysclock_t sysclock);
 
 double alinx_get_ticks_scale(struct pci_dev* pdev);
 void alinx_set_ticks_scale(struct pci_dev* pdev, double ticks_scale);

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -86,7 +86,7 @@ bool tsn_fill_metadata(struct pci_dev* pdev, timestamp_t now, struct sk_buff* sk
 	}
 	consider_delay = (queue_prio != TSN_PRIO_BE);
 
-	from = now + H2C_LATENCY;
+	from = now + H2C_LATENCY_NS;
 
 	duration_ns = bytes_to_ns(metadata->frame_length);
 

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -86,7 +86,7 @@ bool tsn_fill_metadata(struct pci_dev* pdev, timestamp_t now, struct sk_buff* sk
 	}
 	consider_delay = (queue_prio != TSN_PRIO_BE);
 
-	from = now;
+	from = now + H2C_LATENCY;
 
 	duration_ns = bytes_to_ns(metadata->frame_length);
 

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -326,16 +326,16 @@ static bool get_timestamps(struct timestamps* timestamps, const struct tsn_confi
 	slot_count = baked_prio->slot_count;
 
 	// Check if vlan_prio is always open or always closed
-	if (slot_count == 1) {
+	if (slot_count == 2 && baked_prio->slots[1].duration_ns == 0) {
 		if (baked_prio->slots[0].opened == false) {
 			// The only slot is closed. Drop the frame
 			return false;
 		}
 		timestamps->from = from;
-		timestamps->to = from + baked_prio->slots[0].duration_ns - sending_duration;
+		timestamps->to = from - 1;
 		if (consider_delay) {
-			timestamps->delay_from = timestamps->from + baked_prio->slots[0].duration_ns;
-			timestamps->delay_to = timestamps->delay_from + baked_prio->slots[0].duration_ns - sending_duration;
+			timestamps->delay_from = timestamps->from;
+			timestamps->delay_to = timestamps->delay_from - 1;
 		}
 		return true;
 	}

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -323,7 +323,7 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
          * So read it again.
          */
         tx_tstamp = alinx_read_tx_timestamp(priv->pdev, tstamp_id);
-        shhwtstamps.hwtstamp = ns_to_ktime(alinx_get_tx_timestamp2(priv->pdev, tx_tstamp));
+        shhwtstamps.hwtstamp = ns_to_ktime(alinx_sysclock_to_txtstamp(priv->pdev, tx_tstamp));
         priv->last_tx_tstamp[tstamp_id] = tx_tstamp;
 
         priv->tx_work_skb[tstamp_id] = NULL;

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -323,7 +323,7 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
          * So read it again.
          */
         tx_tstamp = alinx_read_tx_timestamp(priv->pdev, tstamp_id);
-        shhwtstamps.hwtstamp = ns_to_ktime(alinx_sysclock_to_timestamp(priv->pdev, tx_tstamp));
+        shhwtstamps.hwtstamp = ns_to_ktime(alinx_get_tx_timestamp2(priv->pdev, tx_tstamp));
         priv->last_tx_tstamp[tstamp_id] = tx_tstamp;
 
         priv->tx_work_skb[tstamp_id] = NULL;


### PR DESCRIPTION
Tx, Rx 타임스탬프에 보정값을 추가하고 Qbv 이슈를 수정했습니다.

1. MAC delay는 측정값대로 Tx, Rx를 각각 100, 188로 했습니다.

2. PHY delay는 Tx, Rx를 각각 200, 324로 추정했습니다.
  - Qbv 슬롯을 벗어나지 않도록 하고, Tx, Rx 간 비율이 MAC 과 비슷하다고 가정해서 대략적인 값으로 추정했습니다.
  - 실제로 측정할 방법이 생기기 전까지는 대략적인 추정값을 사용할 수밖에 없을 것으로 보입니다.

3.  Qbv 계산 중 슬롯이 항상 열려 있거나 닫혀 있는 경우의 처리 방식을 수정했습니다.
  - 현재 bake 할 때 슬롯의 개수를 짝수로 맞춰주고 있기 때문에 항상 상태가 같은지 여부를 판단하는 부분을 이에 맞게 수정했습니다.
  - 슬롯이 항상 열려있는 경우 굳이 to 값을 제한할 필요는 없다고 판단해서, Qbv가 없을 때와 마찬가지로 `to = from - 1`로 설정했습니다.

4. TSN metadata를 채울 때 H2C latency를 고려하도록 했습니다.
  - 대략 3000 클럭 정도의 지연 시간이 있는 것으로 보이지만 편차가 크기 때문에 여유를 주어 30000ns로 설정했습니다.