### PR TITLE
Fix Qbv offset

### DIFF
--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -51,7 +51,7 @@ typedef uint32_t u32
 #define MAX_QBV_SLOTS 20
 
 #define ETHERNET_GAP_SIZE (8 + 4 + 12) // 8 bytes preamble, 4 bytes FCS, 12 bytes interpacket gap
-#define PHY_DELAY_CLOCKS 14 // 14 clocks from MAC to PHY
+#define PHY_DELAY_CLOCKS 13 // 14 clocks from MAC to PHY, but sometimes there is 1 tick error
 
 #define TX_ADJUST_NS (100 + 200)  // MAC + PHY
 #define RX_ADJUST_NS (188 + 324)  // MAC + PHY

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -51,6 +51,10 @@ static bool is_gptp_packet(const uint8_t* payload) {
 	return eth_type == ETH_P_1588;
 }
 
+static inline sysclock_t tsn_timestamp_to_sysclock(struct pci_dev* pdev, timestamp_t timestamp) {
+	return alinx_timestamp_to_sysclock(pdev, timestamp - TX_ADJUST_NS) - PHY_DELAY_CLOCKS;
+}
+
 /**
  * Fill in the time related metadata of a frame
  * @param tsn_config: TSN configuration
@@ -116,13 +120,13 @@ bool tsn_fill_metadata(struct pci_dev* pdev, timestamp_t now, struct sk_buff* sk
 		metadata->fail_policy = consider_delay ? TSN_FAIL_POLICY_RETRY : TSN_FAIL_POLICY_DROP;
 	}
 
-	metadata->from.tick = alinx_timestamp_to_sysclock(pdev, timestamps.from - TX_ADJUST_NS) - PHY_DELAY_CLOCKS;
+	metadata->from.tick = tsn_timestamp_to_sysclock(pdev, timestamps.from);
 	metadata->from.priority = queue_prio;
-	metadata->to.tick = alinx_timestamp_to_sysclock(pdev, timestamps.to - TX_ADJUST_NS) - PHY_DELAY_CLOCKS;
+	metadata->to.tick = tsn_timestamp_to_sysclock(pdev, timestamps.to);
 	metadata->to.priority = queue_prio;
-	metadata->delay_from.tick = alinx_timestamp_to_sysclock(pdev, timestamps.delay_from - TX_ADJUST_NS) - PHY_DELAY_CLOCKS;
+	metadata->delay_from.tick = tsn_timestamp_to_sysclock(pdev, timestamps.delay_from);
 	metadata->delay_from.priority = queue_prio;
-	metadata->delay_to.tick = alinx_timestamp_to_sysclock(pdev, timestamps.delay_to - TX_ADJUST_NS) - PHY_DELAY_CLOCKS;
+	metadata->delay_to.tick = tsn_timestamp_to_sysclock(pdev, timestamps.delay_to);
 	metadata->delay_to.priority = queue_prio;
 
 	if (priv->tstamp_config.tx_type != HWTSTAMP_TX_ON) {

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -116,13 +116,13 @@ bool tsn_fill_metadata(struct pci_dev* pdev, timestamp_t now, struct sk_buff* sk
 		metadata->fail_policy = consider_delay ? TSN_FAIL_POLICY_RETRY : TSN_FAIL_POLICY_DROP;
 	}
 
-	metadata->from.tick = alinx_timestamp_to_sysclock(pdev, timestamps.from) - PHY_DELAY_CLOCKS;
+	metadata->from.tick = alinx_timestamp_to_sysclock(pdev, timestamps.from - TX_ADJUST_NS) - PHY_DELAY_CLOCKS;
 	metadata->from.priority = queue_prio;
-	metadata->to.tick = alinx_timestamp_to_sysclock(pdev, timestamps.to) - PHY_DELAY_CLOCKS;
+	metadata->to.tick = alinx_timestamp_to_sysclock(pdev, timestamps.to - TX_ADJUST_NS) - PHY_DELAY_CLOCKS;
 	metadata->to.priority = queue_prio;
-	metadata->delay_from.tick = alinx_timestamp_to_sysclock(pdev, timestamps.delay_from) - PHY_DELAY_CLOCKS;
+	metadata->delay_from.tick = alinx_timestamp_to_sysclock(pdev, timestamps.delay_from - TX_ADJUST_NS) - PHY_DELAY_CLOCKS;
 	metadata->delay_from.priority = queue_prio;
-	metadata->delay_to.tick = alinx_timestamp_to_sysclock(pdev, timestamps.delay_to) - PHY_DELAY_CLOCKS;
+	metadata->delay_to.tick = alinx_timestamp_to_sysclock(pdev, timestamps.delay_to - TX_ADJUST_NS) - PHY_DELAY_CLOCKS;
 	metadata->delay_to.priority = queue_prio;
 
 	if (priv->tstamp_config.tx_type != HWTSTAMP_TX_ON) {


### PR DESCRIPTION
Qbv에서 슬롯이 열린 후 292ns가 지나야 패킷이 전송되기 시작하던 문제를 수정했습니다.

메타데이터의 타임스탬프 from, to 값에 TX 타임스탬프 보정값을 반영했고,
PHY 딜레이 값을 한 틱 줄여 13으로 했습니다.