### PR TITLE
Revert tc integration

### DIFF
--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -74,15 +74,6 @@ struct ptp_device_data {
 #endif
 };
 
-struct mqprio_config {
-	bool enabled;
-	u8 num_tc;
-	u8 prio_tc_map[TC_QOPT_BITMASK + 1];
-	u16 count[TC_QOPT_MAX_QUEUE];
-	// Ignore offsets
-	// u16 offset[TC_QOPT_MAX_QUEUE];
-};
-
 struct qbv_slot {
 	uint32_t duration_ns; // We don't support cycle > 1s
 	bool opened_prios[VLAN_PRIO_COUNT];
@@ -132,7 +123,6 @@ struct tsn_config {
 	struct qbv_config qbv;
 	struct qbv_baked_config qbv_baked;
 	struct qav_state qav[VLAN_PRIO_COUNT];
-	struct mqprio_config mqprio;
 	struct buffer_tracker buffer_tracker;
 	timestamp_t queue_available_at[TSN_PRIO_COUNT];
 	timestamp_t total_available_at;

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -46,7 +46,7 @@ typedef uint32_t u32
 #define TSN_QUEUE_SIZE (HW_QUEUE_SIZE - 2)
 #define HW_QUEUE_SIZE_PAD 20
 
-#define VLAN_PRIO_COUNT 8
+#define TC_COUNT 8
 #define TSN_PRIO_COUNT 8
 #define MAX_QBV_SLOTS 20
 
@@ -76,7 +76,7 @@ struct ptp_device_data {
 
 struct qbv_slot {
 	uint32_t duration_ns; // We don't support cycle > 1s
-	bool opened_prios[VLAN_PRIO_COUNT];
+	bool opened_prios[TC_COUNT];
 };
 
 struct qbv_config {
@@ -99,7 +99,7 @@ struct qbv_baked_prio {
 
 struct qbv_baked_config {
 	uint64_t cycle_ns;
-	struct qbv_baked_prio prios[VLAN_PRIO_COUNT];
+	struct qbv_baked_prio prios[TC_COUNT];
 };
 
 struct qav_state {
@@ -122,7 +122,7 @@ struct buffer_tracker {
 struct tsn_config {
 	struct qbv_config qbv;
 	struct qbv_baked_config qbv_baked;
-	struct qav_state qav[VLAN_PRIO_COUNT];
+	struct qav_state qav[TC_COUNT];
 	struct buffer_tracker buffer_tracker;
 	timestamp_t queue_available_at[TSN_PRIO_COUNT];
 	timestamp_t total_available_at;

--- a/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -36,6 +36,7 @@ typedef uint32_t u32
 #define REG_TO_OVERFLOW_TIMEOUT_COUNT 0x0424
 
 #define TX_QUEUE_COUNT 3
+#define RX_QUEUE_COUNT 1
 
 /* 125 MHz */
 #define TICKS_SCALE 8.0

--- a/XDMA/linux-kernel/xdma/tsn.c
+++ b/XDMA/linux-kernel/xdma/tsn.c
@@ -463,6 +463,11 @@ int tsn_set_mqprio(struct pci_dev* pdev, struct tc_mqprio_qopt_offload* offload)
 		return ret;
 	}
 
+	if (qopt.num_tc == 0) {
+		// No need to proceed further
+		return 0;
+	}
+
 	for (i = 0; i < qopt.num_tc; i++) {
 		if (netdev_set_tc_queue(xdev->ndev, i, qopt.count[i], qopt.offset[i]) < 0) {
 			pr_warn("Failed to set tc queue: tc [%u], queue [%u@%u]\n", i, qopt.count[i], qopt.offset[i]);
@@ -471,11 +476,6 @@ int tsn_set_mqprio(struct pci_dev* pdev, struct tc_mqprio_qopt_offload* offload)
 
 	for (i = 0; i < TC_QOPT_BITMASK; i++) {
 		if (netdev_set_prio_tc_map(xdev->ndev, i, qopt.prio_tc_map[i]) < 0) {
-			if (qopt.num_tc == 0 && qopt.prio_tc_map[i] == 0) {
-				// For some reason this case is considered "invalid"
-				// even though this is called when qdisc is deleted
-				continue;
-			}
 			pr_warn("Failed to set tc map: prio [%u], tc [%d]\n", i, qopt.prio_tc_map[i]);
 		}
 	}

--- a/XDMA/linux-kernel/xdma/tsn.h
+++ b/XDMA/linux-kernel/xdma/tsn.h
@@ -39,6 +39,6 @@ struct tsn_vlan_hdr {
 bool tsn_fill_metadata(struct pci_dev* pdev, timestamp_t now, struct sk_buff* skb);
 void tsn_init_configs(struct pci_dev* config);
 
-int tsn_set_mqprio(struct pci_dev* pdev, struct tc_mqprio_qopt_offload* qopt);
-int tsn_set_qav(struct pci_dev* pdev, struct tc_cbs_qopt_offload* qopt);
-int tsn_set_qbv(struct pci_dev* pdev, struct tc_taprio_qopt_offload* qopt);
+int tsn_set_mqprio(struct pci_dev* pdev, struct tc_mqprio_qopt_offload* offload);
+int tsn_set_qav(struct pci_dev* pdev, struct tc_cbs_qopt_offload* offload);
+int tsn_set_qbv(struct pci_dev* pdev, struct tc_taprio_qopt_offload* offload);

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -346,10 +346,20 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 	iowrite32(0x10, xdev->bar[0] + 0x620);
 
 	/* Allocate the network device */
-	ndev = alloc_etherdev(sizeof(struct xdma_private));
+	ndev = alloc_etherdev_mq(sizeof(struct xdma_private), TX_QUEUE_COUNT);
 	if (!ndev) {
 		pr_err("alloc_etherdev failed\n");
 		rv = -ENOMEM;
+		goto err_out;
+	}
+	rv = netif_set_real_num_tx_queues(ndev, 1);
+	if (rv) {
+		pr_err("netif_set_real_num_tx_queues failed\n");
+		goto err_out;
+	}
+	rv = netif_set_real_num_rx_queues(ndev, 1);
+	if (rv) {
+		pr_err("netif_set_real_num_rx_queues failed\n");
 		goto err_out;
 	}
 

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -352,11 +352,6 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 		rv = -ENOMEM;
 		goto err_out;
 	}
-	rv = netif_set_real_num_tx_queues(ndev, 1);
-	if (rv) {
-		pr_err("netif_set_real_num_tx_queues failed\n");
-		goto err_out;
-	}
 	rv = netif_set_real_num_rx_queues(ndev, 1);
 	if (rv) {
 		pr_err("netif_set_real_num_rx_queues failed\n");

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -358,7 +358,7 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 	 * TODO: Find out why RX queue count affects throughput
 	 * and see if it can be resolved in another way
 	 */
-	rv = netif_set_real_num_rx_queues(ndev, 1);
+	rv = netif_set_real_num_rx_queues(ndev, RX_QUEUE_COUNT);
 	if (rv) {
 		pr_err("netif_set_real_num_rx_queues failed\n");
 		goto err_out;

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -346,12 +346,18 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 	iowrite32(0x10, xdev->bar[0] + 0x620);
 
 	/* Allocate the network device */
+	/* TC command requires multiple TX queues */
 	ndev = alloc_etherdev_mq(sizeof(struct xdma_private), TX_QUEUE_COUNT);
 	if (!ndev) {
 		pr_err("alloc_etherdev failed\n");
 		rv = -ENOMEM;
 		goto err_out;
 	}
+	/*
+	 * Multiple RX queues drops throughput significantly.
+	 * TODO: Find out why RX queue count affects throughput
+	 * and see if it can be resolved in another way
+	 */
 	rv = netif_set_real_num_rx_queues(ndev, 1);
 	if (rv) {
 		pr_err("netif_set_real_num_rx_queues failed\n");

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -156,7 +156,9 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
         /* Set the fromtick & to_tick values based on the lower 29 bits of the system count */
         if (tsn_fill_metadata(xdev->pdev, now, skb) == false) {
                 // TODO: Increment SW drop stats
-                pr_err("tsn_fill_metadata failed\n");
+#ifdef __LIBXDMA_DEBUG__
+                pr_warn("tsn_fill_metadata failed\n");
+#endif
                 netif_wake_queue(ndev);
                 return NETDEV_TX_BUSY;
         }


### PR DESCRIPTION
성능 문제로 제거되었던 tc 연동 구조를 복원했습니다.

1. 드라이버를 올릴 때 TX 큐만 여러 개를 사용하고, RX 큐는 1개로 했습니다.
  - 이렇게 하면 tc도 사용 가능하고, 대역폭이 감소하지도 않습니다.
  - 다만 RX 큐가 대역폭에 영향을 주는 원리는 추가 조사가 필요합니다.

2. mqprio 설정값을 드라이버가 가지고 있지 않고, 리눅스 커널 API를 통해 가져오도록 했습니다.
  - tc qdisc 명령어로 Qbv(taprio)를 설정하면 mqprio 설정값을 드라이버에 넘겨주지 않고, tc가 자체적으로 리눅스 커널 API를 통해 설정값을 넣습니다.
  - 이에 맞추어 mqprio 명령어가 들어올 때 taprio와 동일하게 작동하도록 수정했습니다.
  - 이 구조는 리눅스 커널 v15.x -> v16.x 에서 크게 바뀌었는데, v16.x 부터는 taprio의 mqprio 설정값을 드라이버에 넘겨줍니다.
  - 이 때 tc는 어떻게 작동하는지는 아직 확인해보지 못했고, 드라이버를 최신 커널에 맞추어 업데이트 해야할 때 확인 및 수정이 필요합니다.

3. TSN QoS 설정이 vlan priority가 아닌 tc(traffic class) id를 기준으로 작동하도록 했습니다.
  - 설계 상 변경점이며, 사실상 변수명 외에 코드 변경점은 없습니다.
  - 만약 mqprio가 설정되지 않았다면 (tc가 없다면) 기존처럼 priority를 기준으로 작동합니다.

4. 사소한 변경점으로, tsn 메타데이터를 채우지 못했을 때 (buffer tracker가 가득 찼을 때) 에러 메시지를 디버그 모드로 빌드했을 때에만 출력하도록 했습니다.
  - 항상 출력하도록 하면 throughput 테스트를 할 때 커널 메시지 수십만 개가 출력되면서 VM이 멈춰버립니다.