### PR TITLE
Fix timestamp issues

### DIFF
--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -315,14 +315,19 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
                 }
                 schedule_work(&priv->tx_work[tstamp_id]);
                 return;
+        } else if (now < tx_tstamp || (now - tx_tstamp) > TX_TSTAMP_UPDATE_THRESHOLD) {
+                /* Tx timestamp is only partially updated */
+                priv->tstamp_retry[tstamp_id]++;
+                if (priv->tstamp_retry[tstamp_id] >= TX_TSTAMP_MAX_RETRY) {
+                        /* TODO: track the number of skipped packets for ethtool stats */
+                        priv->tstamp_retry[tstamp_id] = 0;
+                        clear_bit_unlock(tstamp_id, &priv->state);
+                        return;
+                }
+                schedule_work(&priv->tx_work[tstamp_id]);
+                return;
         }
         priv->tstamp_retry[tstamp_id] = 0;
-        /*
-         * Tx timestamp is updated, or getting updated.
-         * If it is getting updated, the value might be incorrect.
-         * So read it again.
-         */
-        tx_tstamp = alinx_read_tx_timestamp(priv->pdev, tstamp_id);
         shhwtstamps.hwtstamp = ns_to_ktime(alinx_sysclock_to_txtstamp(priv->pdev, tx_tstamp));
         priv->last_tx_tstamp[tstamp_id] = tx_tstamp;
 

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -307,7 +307,7 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
                  * Waiting for it to be updated forever is not desirable,
                  * so limit the number of retries
                  */
-                if (++priv->tstamp_retry[tstamp_id] >= TX_TSTAMP_MAX_RETRY) {
+                if (++(priv->tstamp_retry[tstamp_id]) >= TX_TSTAMP_MAX_RETRY) {
                         /* TODO: track the number of skipped packets for ethtool stats */
                         pr_warn("Failed to get timestamp: timestamp is not getting updated, " \
                                 "the packet might have been dropped\n");
@@ -316,7 +316,7 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
                 goto retry;
         } else if (now - tx_tstamp > TX_TSTAMP_UPDATE_THRESHOLD) {
                 /* Tx timestamp is only partially updated */
-                if (++priv->tstamp_retry[tstamp_id] >= TX_TSTAMP_MAX_RETRY) {
+                if (++(priv->tstamp_retry[tstamp_id]) >= TX_TSTAMP_MAX_RETRY) {
                         /* TODO: track the number of skipped packets for ethtool stats */
                         pr_err("Failed to get timestamp: timestamp is only partially updated\n");
 			pr_err("%llx %llx %llu\n", now, tx_tstamp, now - tx_tstamp);

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -313,7 +313,7 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
                 priv->tstamp_retry[tstamp_id]++;
                 if (priv->tstamp_retry[tstamp_id] >= TX_TSTAMP_MAX_RETRY) {
                         /* TODO: track the number of skipped packets for ethtool stats */
-                        pr_err("Failed to get timestamp: timestamp is not getting updated\n");
+                        pr_warn("Failed to get timestamp: timestamp is not getting updated, the packet might have been dropped\n");
                         priv->tstamp_retry[tstamp_id] = 0;
                         clear_bit_unlock(tstamp_id, &priv->state);
                         return;

--- a/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -285,13 +285,11 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
         }
 
         if (!priv->tx_work_skb[tstamp_id]) {
-                clear_bit_unlock(tstamp_id, &priv->state);
-                return;
+                goto return_error;
         }
 
         if (now < priv->tx_work_start_after[tstamp_id]) {
-                schedule_work(&priv->tx_work[tstamp_id]);
-                return;
+                goto retry;
         }
         /*
          * Read TX timestamp several times because
@@ -299,39 +297,32 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
          * 2. The work thread might try to read TX timestamp before the register gets updated
          */
         tx_tstamp = alinx_read_tx_timestamp(priv->pdev, tstamp_id);
-        if (tx_tstamp == priv->last_tx_tstamp[tstamp_id] && priv->tstamp_retry[tstamp_id] < TX_TSTAMP_MAX_RETRY) {
+        if (tx_tstamp == priv->last_tx_tstamp[tstamp_id]) {
                 if (alinx_get_sys_clock(priv->xdev->pdev) < priv->tx_work_wait_until[tstamp_id]) {
                         /* The packet might have not been sent yet */
-                        schedule_work(&priv->tx_work[tstamp_id]);
-                        return;
+                        goto retry;
                 }
                 /*
                  * Tx timestamp is not updated. Try again.
                  * Waiting for it to be updated forever is not desirable,
                  * so limit the number of retries
                  */
-                priv->tstamp_retry[tstamp_id]++;
-                if (priv->tstamp_retry[tstamp_id] >= TX_TSTAMP_MAX_RETRY) {
+                if (++priv->tstamp_retry[tstamp_id] >= TX_TSTAMP_MAX_RETRY) {
                         /* TODO: track the number of skipped packets for ethtool stats */
-                        pr_warn("Failed to get timestamp: timestamp is not getting updated, the packet might have been dropped\n");
-                        priv->tstamp_retry[tstamp_id] = 0;
-                        clear_bit_unlock(tstamp_id, &priv->state);
-                        return;
+                        pr_warn("Failed to get timestamp: timestamp is not getting updated, " \
+                                "the packet might have been dropped\n");
+                        goto return_error;
                 }
-                schedule_work(&priv->tx_work[tstamp_id]);
-                return;
-        } else if (now < tx_tstamp || (now - tx_tstamp) > TX_TSTAMP_UPDATE_THRESHOLD) {
+                goto retry;
+        } else if (now - tx_tstamp > TX_TSTAMP_UPDATE_THRESHOLD) {
                 /* Tx timestamp is only partially updated */
-                priv->tstamp_retry[tstamp_id]++;
-                if (priv->tstamp_retry[tstamp_id] >= TX_TSTAMP_MAX_RETRY) {
+                if (++priv->tstamp_retry[tstamp_id] >= TX_TSTAMP_MAX_RETRY) {
                         /* TODO: track the number of skipped packets for ethtool stats */
                         pr_err("Failed to get timestamp: timestamp is only partially updated\n");
-                        priv->tstamp_retry[tstamp_id] = 0;
-                        clear_bit_unlock(tstamp_id, &priv->state);
-                        return;
+			pr_err("%llx %llx %llu\n", now, tx_tstamp, now - tx_tstamp);
+                        goto return_error;
                 }
-                schedule_work(&priv->tx_work[tstamp_id]);
-                return;
+                goto retry;
         }
         priv->tstamp_retry[tstamp_id] = 0;
         shhwtstamps.hwtstamp = ns_to_ktime(alinx_sysclock_to_txtstamp(priv->pdev, tx_tstamp));
@@ -341,6 +332,16 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
         clear_bit_unlock(tstamp_id, &priv->state);
         skb_tstamp_tx(skb, &shhwtstamps);
         dev_kfree_skb_any(skb);
+        return;
+
+return_error:
+	priv->tstamp_retry[tstamp_id] = 0;
+	clear_bit_unlock(tstamp_id, &priv->state);
+	return;
+
+retry:
+	schedule_work(&priv->tx_work[tstamp_id]);
+	return;
 }
 
 #define DEFINE_TX_WORK(n) \

--- a/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -27,6 +27,7 @@
 #define CRC_LEN 4
 
 #define TX_TSTAMP_MAX_RETRY 5
+#define TX_TSTAMP_UPDATE_THRESHOLD 0xFFFFFF
 
 enum xdma_state_t {
         XDMA_TX1_IN_PROGRESS = 1,

--- a/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -27,7 +27,15 @@
 #define CRC_LEN 4
 
 #define TX_TSTAMP_MAX_RETRY 5
-#define TX_TSTAMP_UPDATE_THRESHOLD 0xFFFFFF
+
+/**
+ * The delay between packet transmission and timestamp read
+ * should not exceed 0xFFFF. (actually a delay greater than
+ * 0x1000 has not been observed, but there's no need to be strict)
+ * Errors less than 0xFFFF are not detectable from SW since
+ * HW updates timestamp by two bytes at a time.
+ */
+#define TX_TSTAMP_UPDATE_THRESHOLD 0xFFFF
 
 enum xdma_state_t {
         XDMA_TX1_IN_PROGRESS = 1,

--- a/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -29,13 +29,13 @@
 #define TX_TSTAMP_MAX_RETRY 5
 
 /**
- * The delay between packet transmission and timestamp read
- * should not exceed 0xFFFF. (actually a delay greater than
- * 0x1000 has not been observed, but there's no need to be strict)
- * Errors less than 0xFFFF are not detectable from SW since
- * HW updates timestamp by two bytes at a time.
+ * This value is estimated by experiment.
+ * There might be a delay greater than this,
+ * or an error less than this.
+ * But that's not detectable by SW, until
+ * reading Tx timestamp becomes atomic.
  */
-#define TX_TSTAMP_UPDATE_THRESHOLD 0xFFFF
+#define TX_TSTAMP_UPDATE_THRESHOLD 0xFFFFF
 
 enum xdma_state_t {
         XDMA_TX1_IN_PROGRESS = 1,


### PR DESCRIPTION
단방향 테스트 중 발견된 타임스탬프 / 패킷 누락 이슈를 수정했습니다.

1. Tx 타임스탬프를 읽을 때 단순히 여러 번 읽지 않고 부분적으로 업데이트된 것을 탐지해서 다시 읽도록 했습니다.
 - 한 번 더 읽어도 여전히 업데이트가 완전히 되지 않은 경우가 있었습니다.
 - 타임스탬프와 현재 시간의 차이가 일정 수치를 넘으면 업데이트가 제대로 되지 않은 것으로 판단하도록 했습니다.

2. 메타데이터 계산 중 발생하는 버그를 수정했습니다.
 - 기존에 Qbv가 없거나 항상 열려 있는 상태일 경우 `to` 값을 `from - 1`로 하도록 되어 있는데, 이 경우 타임스탬프를 tick 단위로 변환하는 과정에서 가끔씩 from, to 값이 같아지는 경우가 있었고, 이로 인해 timeout이 발생했습니다.
 - 이를 해결하기 위해 timestamp -> sysclock 변환 과정에 예외 처리를 추가했습니다.