### PR TITLE
Make XDMA driver compatible with linux kernel >= 5.16

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -233,8 +233,12 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	 * prevent touching the pages (byte access) for swap-in,
 	 * and prevent the pages from being swapped out
 	 */
-	vma->vm_flags |= VMEM_FLAGS;
-	/* make MMIO accessible to user space */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+	vm_flags_mod(vma, VMEM_FLAGS, 0);
+#else
+	vma->vm_flags |= VMEM_FLAGS; /* make MMIO accessible to user space */
+#endif
+
 	rv = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,
 			vsize, vma->vm_page_prot);
 	dbg_sg("vma=0x%p, vma->vm_start=0x%lx, phys=0x%lx, size=%lu = %d\n",

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -104,7 +104,9 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 	if (caio->cmpl_cnt == caio->req_cnt) {
 		res = caio->res;
 		res2 = caio->res2;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
+		caio->iocb->ki_complete(caio->iocb, res);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
 		caio->iocb->ki_complete(caio->iocb, res, res2);
 #else
 		aio_complete(caio->iocb, res, res2);
@@ -119,7 +121,9 @@ skip_tran:
 	return;
 
 skip_dev_lock:
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
+	caio->iocb->ki_complete(caio->iocb, res);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
 	caio->iocb->ki_complete(caio->iocb, numbytes, -EBUSY);
 #else
 	aio_complete(caio->iocb, numbytes, -EBUSY);
@@ -623,12 +627,20 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 static ssize_t cdev_write_iter(struct kiocb *iocb, struct iov_iter *io)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	return cdev_aio_write(iocb, iter_iov(io), io->nr_segs, io->iov_offset);
+#else
 	return cdev_aio_write(iocb, io->iov, io->nr_segs, io->iov_offset);
+#endif
 }
 
 static ssize_t cdev_read_iter(struct kiocb *iocb, struct iov_iter *io)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	return cdev_aio_read(iocb, iter_iov(io), io->nr_segs, io->iov_offset);
+#else
 	return cdev_aio_read(iocb, io->iov, io->nr_segs, io->iov_offset);
+#endif
 }
 #endif
 

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -2946,7 +2946,7 @@ static void transfer_destroy(struct xdma_dev *xdev, struct xdma_transfer *xfer)
 		struct sg_table *sgt = xfer->sgt;
 
 		if (sgt->nents) {
-			pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->nents,
+			dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->nents,
 				     xfer->dir);
 			sgt->nents = 0;
 		}
@@ -3229,7 +3229,7 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 	}
 
 	if (!dma_mapped) {
-		sgt->nents = pci_map_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
+		sgt->nents = dma_map_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->orig_nents,
 					dir);
 		if (!sgt->nents) {
 			pr_info("map sgl failed, sgt 0x%p.\n", sgt);
@@ -3468,7 +3468,7 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -3538,7 +3538,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 	}
 
 	if (!dma_mapped) {
-		nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, dir);
+		nents = dma_map_sg(&(xdev->pdev)->dev, sg, sgt->orig_nents, dir);
 		if (!nents) {
 			pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -3693,7 +3693,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -3721,7 +3721,7 @@ ssize_t xdma_multi_buffer_xfer_submit(struct xdma_engine *engine, int channel, b
 		return -EBUSY;
 	}
 
-	nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, dir);
+	nents = dma_map_sg(&(xdev->pdev)->dev, sg, sgt->orig_nents, dir);
 	if (!nents) {
 		pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 		return -EIO;
@@ -3878,7 +3878,7 @@ ssize_t xdma_multi_buffer_xfer_submit(struct xdma_engine *engine, int channel, b
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -3999,7 +3999,7 @@ ssize_t xdma_xfer_completion(void *cb_hndl, void *dev_hndl, int channel,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -4073,7 +4073,7 @@ ssize_t xdma_xfer_submit_nowait(void *cb_hndl, void *dev_hndl, int channel,
 	}
 
 	if (!dma_mapped) {
-		nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, dir);
+		nents = dma_map_sg(&(xdev->pdev)->dev, sg, sgt->orig_nents, dir);
 		if (!nents) {
 			pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -4113,7 +4113,7 @@ ssize_t xdma_xfer_submit_nowait(void *cb_hndl, void *dev_hndl, int channel,
 			pr_info("transfer_init failed\n");
 
 			if (!dma_mapped && sgt->nents) {
-				pci_unmap_sg(xdev->pdev, sgt->sgl,
+				dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl,
 						sgt->orig_nents, dir);
 				sgt->nents = 0;
 			}
@@ -4161,7 +4161,7 @@ ssize_t xdma_xfer_submit_nowait(void *cb_hndl, void *dev_hndl, int channel,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -4409,16 +4409,16 @@ static int set_dma_mask(struct pci_dev *pdev)
 
 	dbg_init("sizeof(dma_addr_t) == %ld\n", sizeof(dma_addr_t));
 	/* 64-bit addressing capability for XDMA? */
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) {
+	if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(64))) {
 		/* query for DMA transfer */
 		/* @see Documentation/DMA-mapping.txt */
 		dbg_init("pci_set_dma_mask()\n");
 		/* use 64-bit DMA */
 		dbg_init("Using a 64-bit DMA mask.\n");
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(64));
-	} else if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) {
+		dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
+	} else if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(32))) {
 		dbg_init("Could not set 64-bit DMA mask.\n");
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
 		/* use 32-bit DMA */
 		dbg_init("Using a 32-bit DMA mask.\n");
 	} else {


### PR DESCRIPTION
[링크](https://github.com/Xilinx/dma_ip_drivers/pull/216/files#diff-09384e6aa73a33b0ee86c6c5efe15d401a5e0c87596de0b68a05d86efdc40506L2911-R2911) 참고하여 커널 버전 `6.2.16-20-pve`에서 동작 가능하도록 수정하였습니다.

- reference
[Make XDMA driver compatible with linux kernel >= 5.16](https://github.com/Xilinx/dma_ip_drivers/pull/216/files#diff-09384e6aa73a33b0ee86c6c5efe15d401a5e0c87596de0b68a05d86efdc40506L2911-R2911)